### PR TITLE
Addition of files - bin/preprint_bot_summarizer and src/preprint_bot_summarization.py

### DIFF
--- a/bin/preprint_bot_summarizer
+++ b/bin/preprint_bot_summarizer
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+CLI launcher for preprint_bot.preprint_bot_summarization
+Allows running from command line without directly calling the module.
+"""
+
+import argparse
+from preprint_bot.preprint_bot_summarization import process_arxiv_query
+ # updated import
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch arXiv papers and summarize abstracts.")
+    parser.add_argument("query", help="Search term for arXiv")
+    parser.add_argument("--max_results", type=int, default=5, help="Number of papers to fetch")
+    parser.add_argument("--models", type=str, nargs="+", default=["facebook/bart-large-cnn"],
+                        help="List of models to use for summarization")
+    parser.add_argument("--max_length", type=int, default=180, help="Max length of summary")
+    args = parser.parse_args()
+
+    process_arxiv_query(
+        query=args.query,
+        max_results=args.max_results,
+        models=args.models,
+        max_length=args.max_length
+    )
+
+if __name__ == "__main__":
+    main()
+

--- a/src/preprint_bot/preprint_bot_summarization.py
+++ b/src/preprint_bot/preprint_bot_summarization.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+preprint_bot_summarization.py
+
+Fetches arXiv papers, saves text/metadata, and summarizes abstracts using transformer models.
+"""
+
+import argparse
+from pathlib import Path
+from urllib.parse import quote
+import feedparser
+import re
+import csv
+from summarization_script import summarize_with_transformer  # Transformer-based summarization function
+
+# ------------------------
+# Folders for input/output
+# ------------------------
+INPUT_FOLDER = Path("input_folder")     # Folder to store raw paper text files
+OUTPUT_FOLDER = Path("summaries")       # Folder to store summarized outputs
+
+def create_folders():
+    """Create input and output folders if they don't already exist."""
+    INPUT_FOLDER.mkdir(parents=True, exist_ok=True)
+    OUTPUT_FOLDER.mkdir(parents=True, exist_ok=True)
+
+# ------------------------
+# Text cleaning helpers
+# ------------------------
+def clean_whitespace(text):
+    """Remove non-breaking spaces, tabs, and extra spaces from text."""
+    text = text.replace("\xa0", " ")
+    return re.sub(r'\s+', ' ', text).strip()
+
+def clean_text(text):
+    """
+    Clean text by removing boilerplate, repeated sentences,
+    extra periods, and normalizing whitespace.
+    """
+    text = re.sub(r'Continued on this page(\.*)', '', text, flags=re.IGNORECASE)
+    text = re.sub(r'\.{2,}', '.', text)
+    text = re.sub(r'\s+', ' ', text).strip()
+    sentences = text.split('. ')
+    seen = set()
+    unique_sentences = []
+    for s in sentences:
+        s_clean = s.strip()
+        if s_clean and s_clean not in seen:
+            seen.add(s_clean)
+            unique_sentences.append(s_clean)
+    return '. '.join(unique_sentences)
+
+# ------------------------
+# Fetch arXiv papers
+# ------------------------
+def fetch_arxiv_papers(query, max_results=5):
+    """Query arXiv API and return a list of paper entries."""
+    base_url = "http://export.arxiv.org/api/query?"
+    encoded_query = quote(query)
+    search_query = f"search_query=all:{encoded_query}&start=0&max_results={max_results}"
+    feed = feedparser.parse(base_url + search_query)
+    return feed.entries
+
+# ------------------------
+# Save paper text files
+# ------------------------
+def save_paper_txt(paper, index):
+    """Save a single paper's title and abstract to a TXT file."""
+    arxiv_id = paper.id.split("/")[-1]
+    file_path = INPUT_FOLDER / f"{index}_{arxiv_id}.txt"
+    clean_title = clean_whitespace(paper.title)
+    clean_abstract = clean_text(paper.summary)
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(f"Title: {clean_title}\n\n")
+        f.write(f"Abstract:\n{clean_abstract}\n")
+    return file_path
+
+# ------------------------
+# Save metadata CSV
+# ------------------------
+def save_metadata(papers):
+    """Save metadata (Index, ArxivID, Title, Authors) of fetched papers to CSV."""
+    metadata_file = INPUT_FOLDER / "metadata.csv"
+    with open(metadata_file, "w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["Index", "ArxivID", "Title", "Authors"])
+        for idx, paper in enumerate(papers, start=1):
+            authors = ", ".join([author.name for author in paper.authors])
+            writer.writerow([idx, paper.id.split("/")[-1], paper.title, authors])
+    print(f"✅ Metadata saved: {metadata_file}")
+
+# ------------------------
+# Summarize abstract
+# ------------------------
+def summarize_paper(file_path, model_name, paper_index, max_length=180):
+    """Generate summary for a paper using the transformer model and save it."""
+    with open(file_path, "r", encoding="utf-8") as f:
+        txt = f.read()
+    match = re.search(r"Abstract:\s*(.*)", txt, re.DOTALL)
+    if not match:
+        print(f"⚠ No abstract found in {file_path.name}")
+        return
+    abstract_text = clean_text(match.group(1))
+    summary = summarize_with_transformer(
+        abstract_text, model_name=model_name, max_length=max_length
+    )
+    summary = clean_whitespace(summary)
+    model_folder = OUTPUT_FOLDER / model_name.replace("/", "_")
+    model_folder.mkdir(parents=True, exist_ok=True)
+    output_file = model_folder / f"{paper_index}_{model_name.replace('/', '_')}_summary.txt"
+    with open(output_file, "w", encoding="utf-8") as f:
+        f.write(summary)
+    print(f"✅ Summary saved: {output_file}")
+
+# ------------------------
+# Wrapper function for CLI or imports
+# ------------------------
+def process_arxiv_query(query, max_results=5, models=None, max_length=180):
+    """
+    High-level function to:
+    1. Create folders
+    2. Fetch papers
+    3. Save text and metadata
+    4. Summarize using specified models
+    """
+    if models is None:
+        models = ["facebook/bart-large-cnn"]
+    create_folders()
+    papers = fetch_arxiv_papers(query, max_results)
+    save_metadata(papers)
+    for idx, paper in enumerate(papers, start=1):
+        txt_file = save_paper_txt(paper, idx)
+        for model in models:
+            summarize_paper(txt_file, model_name=model, paper_index=idx, max_length=max_length)
+
+# ------------------------
+# CLI entry point
+# ------------------------
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Fetch arXiv papers and summarize abstracts.")
+    parser.add_argument("query", help="Search term for arXiv")
+    parser.add_argument("--max_results", type=int, default=5)
+    parser.add_argument("--models", type=str, nargs="+", default=["facebook/bart-large-cnn"])
+    parser.add_argument("--max_length", type=int, default=180)
+    args = parser.parse_args()
+    process_arxiv_query(
+        args.query,
+        max_results=args.max_results,
+        models=args.models,
+        max_length=args.max_length
+    )
+


### PR DESCRIPTION
- **Preprint_bot_Summarization.py** :

preprint_bot_summarization.py is a Python script that automates the process of fetching academic papers from arXiv, saving the text and metadata, and generating summaries of abstracts using transformer-based models (like facebook/bart-large-cnn).

What the Script Does: 

Fetches papers from arXiv based on a search query.

Saves paper titles and abstracts as text files in a dedicated folder (input_folder).

Saves metadata (authors, IDs, titles) as a CSV file.

Cleans text and removes duplicate sentences or boilerplate.

Summarizes abstracts using transformer models and saves the summaries in a separate folder (summaries), organized by model.

How to run the script:
python preprint_bot_summarization.py "your search query" --max_results 5 --models facebook/bart-large-cnn t5-base --max_length __


"your search query" → Replace with your desired search term, e.g., "graph neural networks".

--max_results → Number of papers to fetch (default: 5).

--models → List of transformer models to summarize abstracts (default: ["facebook/bart-large-cnn"]).

--max_length → Maximum length of summary (default: 180 tokens).

- **Preprint_bot_summarizer** :

cli_summarizer.py is a command-line launcher for the preprint_bot.preprint_bot_summarization module.

Purpose:
It allows users to fetch arXiv papers and generate abstract summaries directly from the command line, without needing to import or run the main Python module manually.

Key Features:

Accepts a search query to fetch papers from arXiv.

Allows specifying the number of papers (--max_results).

Supports multiple transformer models for summarization (--models).

Can control maximum summary length (--max_length).

Calls the process_arxiv_query function from preprint_bot_summarization under the hood.
