### PR TITLE
Fix handling of non-daily email frequencies

### DIFF
--- a/django_site/core/migrations/0009_recommendation_sent_in_email.py
+++ b/django_site/core/migrations/0009_recommendation_sent_in_email.py
@@ -1,0 +1,37 @@
+"""
+Add sent_in_email boolean to recommendations table for digest rollup,
+and add index on sent_in_email. Existing recommendations are backfilled
+as already sent so the first digest after deployment doesn't re-send
+everything.
+"""
+
+from django.db import migrations, models
+
+
+def backfill_sent_in_email(apps, schema_editor):
+    """Mark all existing recommendations as already sent."""
+    Recommendation = apps.get_model("core", "Recommendation")
+    Recommendation.objects.all().update(sent_in_email=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0008_alter_paper_corpus_alter_pbuser_password_and_more"),
+    ]
+
+    operations = [
+        # Add sent_in_email boolean to Recommendation
+        migrations.AddField(
+            model_name="recommendation",
+            name="sent_in_email",
+            field=models.BooleanField(default=False),
+        ),
+        # Backfill existing recommendations as already sent
+        migrations.RunPython(backfill_sent_in_email, migrations.RunPython.noop),
+        # Index for fast unsent-recommendation queries
+        migrations.AddIndex(
+            model_name="recommendation",
+            index=models.Index(fields=["sent_in_email"], name="recommendations_sent_idx"),
+        ),
+    ]

--- a/django_site/core/models.py
+++ b/django_site/core/models.py
@@ -309,11 +309,15 @@ class Recommendation(models.Model):
     score = models.FloatField()
     rank = models.IntegerField()
     summary = models.TextField(blank=True, null=True)
+    sent_in_email = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
         db_table = "recommendations"
         unique_together = [("run", "paper")]
+        indexes = [
+            models.Index(fields=["sent_in_email"], name="recommendations_sent_idx"),
+        ]
 
 
 # ── Profile ↔ Recommendation junction ─────────────────────────────────────

--- a/routes/emails.py
+++ b/routes/emails.py
@@ -19,7 +19,6 @@ class DigestRequest(BaseModel):
 async def send_digest(req: DigestRequest):
     pool = await get_db_pool()
     run_date = req.run_date or str(date.today())
-    run_date_obj = datetime.strptime(run_date, "%Y-%m-%d").date()
 
     async with pool.acquire() as conn:
         user = await conn.fetchrow(
@@ -29,7 +28,7 @@ async def send_digest(req: DigestRequest):
             raise HTTPException(status_code=404, detail="User not found")
 
         profile = await conn.fetchrow(
-            "SELECT id, name, email_notify, top_x FROM profiles WHERE id = $1 AND user_id = $2",
+            "SELECT id, name, email_notify, top_x, frequency FROM profiles WHERE id = $1 AND user_id = $2",
             req.profile_id, req.user_id
         )
         if not profile:
@@ -40,26 +39,32 @@ async def send_digest(req: DigestRequest):
 
         top_x = profile["top_x"] or 10
 
+        # Fetch all unsent recommendations for this profile
         rows = await conn.fetch(
             """
-            SELECT p.arxiv_id, p.title, p.abstract, r.score, r.summary, s.summary_text
-            FROM profile_recommendations pr
-            JOIN recommendations r ON r.id = pr.recommendation_id
+            SELECT r.id AS recommendation_id,
+                   p.arxiv_id, p.title, p.abstract,
+                   r.score, r.summary, s.summary_text
+            FROM recommendations r
             JOIN recommendation_runs rr ON rr.id = r.run_id
             JOIN papers p ON p.id = r.paper_id
-            LEFT JOIN summaries s ON s.paper_id = p.id
-            WHERE pr.profile_id = $1
-            AND rr.target_date = $2
+            LEFT JOIN summaries s ON s.paper_id = p.id AND s.mode = 'abstract'
+            WHERE rr.profile_id = $1
+              AND r.sent_in_email = false
             ORDER BY r.score DESC
-            LIMIT $3
+            LIMIT $2
             """,
-            req.profile_id, run_date_obj, top_x
+            req.profile_id, top_x
         )
 
         if not rows:
-            return {"status": "skipped", "reason": "no recommendations found for this date"}
+            return {"status": "skipped", "reason": "no unsent recommendations found"}
 
+        # Collect recommendation IDs for marking as sent
+        rec_ids = [row["recommendation_id"] for row in rows]
         papers = [dict(r) for r in rows]
+
+    frequency = profile["frequency"] or "daily"
 
     success, subject, html_body = await run_in_threadpool(
         send_recommendations_digest,
@@ -67,6 +72,7 @@ async def send_digest(req: DigestRequest):
         profile_name=profile["name"],
         papers=papers,
         run_date=run_date,
+        frequency=frequency,
     )
 
     status = "sent" if success else "failed"
@@ -79,6 +85,13 @@ async def send_digest(req: DigestRequest):
             """,
             req.user_id, req.profile_id, subject, html_body, status
         )
+
+        # Only mark recommendations as sent if the email actually succeeded
+        if success:
+            await conn.execute(
+                "UPDATE recommendations SET sent_in_email = true WHERE id = ANY($1)",
+                rec_ids,
+            )
 
     if not success:
         raise HTTPException(status_code=500, detail="Email sending failed")

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -21,7 +21,7 @@ def truncate_to_sentences(text: str, n: int = 3) -> tuple[str, bool]:
     return ' '.join(sentences[:n]), True
 
 
-def build_digest_html(profile_name: str, papers: List[Dict], run_date: str, shown: int, total: int) -> str:
+def build_digest_html(profile_name: str, papers: List[Dict], run_date: str, shown: int, total: int, frequency: str = "daily") -> str:
     papers = papers[:10]
     rows = ""
     for i, paper in enumerate(papers, 1):
@@ -48,12 +48,14 @@ def build_digest_html(profile_name: str, papers: List[Dict], run_date: str, show
 
     count_line = f"Showing {shown} out of {total} recommendations" if total > 10 else f"Showing {total} out of {total} recommendations"
 
+    header_label = {"weekly": "Weekly", "monthly": "Monthly"}.get(frequency, "New")
+
     return f"""
     <html><body style="font-family:Arial,sans-serif;background:#f9f9f9;margin:0;padding:0;">
     <div style="max-width:700px;margin:30px auto;background:#fff;border-radius:8px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.1);">
         <div style="background:{SU_NAVY};padding:24px 32px;">
             <h1 style="margin:0;font-size:22px;"><a href="{DASHBOARD_URL}" style="color:{SU_ORANGE};text-decoration:none;">Preprint Bot</a></h1>
-            <p style="color:#cce0ff;margin:4px 0 0;font-size:14px;">Daily Recommendations &mdash; {run_date}</p>
+            <p style="color:#cce0ff;margin:4px 0 0;font-size:14px;">{header_label} Recommendations &mdash; {run_date}</p>
         </div>
         <div style="padding:24px 32px;">
             <p style="font-size:15px;color:#333;">Here are your top recommendations for profile <strong>{profile_name}</strong>:</p>
@@ -97,10 +99,12 @@ def send_recommendations_digest(
     profile_name: str,
     papers: List[Dict],
     run_date: str,
+    frequency: str = "daily",
 ) -> tuple[bool, str, str]:
     total = len(papers)
     shown = min(total, 10)
-    subject = f"Preprint Bot: {total} new recommendations for '{profile_name}' ({run_date})"
-    html_body = build_digest_html(profile_name, papers, run_date, shown, total)
+    digest_label = {"weekly": "weekly digest", "monthly": "monthly digest"}.get(frequency, run_date)
+    subject = f"Preprint Bot: {total} new recommendations for '{profile_name}' ({digest_label})"
+    html_body = build_digest_html(profile_name, papers, run_date, shown, total, frequency)
     success = send_email(to_address, subject, html_body)
     return success, subject, html_body

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -48,7 +48,7 @@ def build_digest_html(profile_name: str, papers: List[Dict], run_date: str, show
 
     count_line = f"Showing {shown} out of {total} recommendations" if total > 10 else f"Showing {total} out of {total} recommendations"
 
-    header_label = {"weekly": "Weekly", "monthly": "Monthly"}.get(frequency, "New")
+    header_label = {"daily": "Daily", "weekly": "Weekly", "monthly": "Monthly"}.get(frequency, "New")
 
     return f"""
     <html><body style="font-family:Arial,sans-serif;background:#f9f9f9;margin:0;padding:0;">
@@ -103,7 +103,7 @@ def send_recommendations_digest(
 ) -> tuple[bool, str, str]:
     total = len(papers)
     shown = min(total, 10)
-    digest_label = {"weekly": "weekly digest", "monthly": "monthly digest"}.get(frequency, run_date)
+    digest_label = {"daily": run_date, "weekly": f"weekly digest \u00b7 {run_date}", "monthly": f"monthly digest \u00b7 {run_date}"}.get(frequency, run_date)
     subject = f"Preprint Bot: {total} new recommendations for '{profile_name}' ({digest_label})"
     html_body = build_digest_html(profile_name, papers, run_date, shown, total, frequency)
     success = send_email(to_address, subject, html_body)


### PR DESCRIPTION
- New table column that indicates whether a recommendation has been emailed about
- Use this new column as the filter instead of a published timestamp
- Backfill all existing recommendations as emailed
- Update email template to include information about the email frequency in subject and body

Fixes #51