### PR TITLE
Add text layer validation for PDF uploads

### DIFF
--- a/django_site/core/views.py
+++ b/django_site/core/views.py
@@ -123,6 +123,32 @@ def _link_paper_to_corpus(paper, corpus):
     paper.corpora.add(corpus)
 
 
+def _pdf_has_text_layer(uploaded_file, min_chars=50, max_pages=3):
+    """Check whether a PDF has extractable text.
+
+    Reads up to *max_pages* pages and returns True if at least
+    *min_chars* non-whitespace characters can be extracted.
+    Returns True (allow upload) if pypdf is not installed or the
+    PDF cannot be parsed, so we never block uploads due to a
+    library issue.
+    """
+    try:
+        from io import BytesIO
+        from pypdf import PdfReader
+
+        data = uploaded_file.read()
+        uploaded_file.seek(0)
+        reader = PdfReader(BytesIO(data))
+        text = ""
+        for page in reader.pages[:max_pages]:
+            text += page.extract_text() or ""
+            if len(text.strip()) >= min_chars:
+                return True
+        return len(text.strip()) >= min_chars
+    except Exception:
+        return True  # don't block uploads if the check itself fails
+
+
 # ── Decorator ──────────────────────────────────────────────────────────────
 
 def pbuser_required(view_func):
@@ -770,6 +796,16 @@ def paper_upload_view(request, profile_id):
         f.seek(0)
         if b"%PDF-" not in header:
             messages.warning(request, f"Skipped {safe_name}: not a valid PDF file.")
+            skipped += 1
+            continue
+
+        # Check for extractable text layer (reject scanned/image-only PDFs)
+        if not _pdf_has_text_layer(f):
+            messages.warning(
+                request,
+                f"Skipped {safe_name}: no extractable text found. "
+                f"Please upload a PDF with a text layer (not a scanned image).",
+            )
             skipped += 1
             continue
 

--- a/django_site/core/views.py
+++ b/django_site/core/views.py
@@ -127,25 +127,27 @@ def _pdf_has_text_layer(uploaded_file, min_chars=50, max_pages=3):
     """Check whether a PDF has extractable text.
 
     Reads up to *max_pages* pages and returns True if at least
-    *min_chars* non-whitespace characters can be extracted.
+    *min_chars* characters of text (after stripping leading/trailing
+    whitespace) can be extracted.
     Returns True (allow upload) if pypdf is not installed or the
     PDF cannot be parsed, so we never block uploads due to a
     library issue.
     """
     try:
-        from io import BytesIO
         from pypdf import PdfReader
 
-        data = uploaded_file.read()
         uploaded_file.seek(0)
-        reader = PdfReader(BytesIO(data))
+        reader = PdfReader(uploaded_file)
         text = ""
         for page in reader.pages[:max_pages]:
             text += page.extract_text() or ""
             if len(text.strip()) >= min_chars:
+                uploaded_file.seek(0)
                 return True
+        uploaded_file.seek(0)
         return len(text.strip()) >= min_chars
     except Exception:
+        uploaded_file.seek(0)
         return True  # don't block uploads if the check itself fails
 
 

--- a/django_site/requirements.txt
+++ b/django_site/requirements.txt
@@ -9,3 +9,6 @@ pgvector>=0.3.6
 # Only needed if you want the paper-add-from-arXiv feature to work
 requests>=2.31.0
 arxiv>=2.1.0
+
+# PDF text layer validation on upload
+pypdf>=4.0.0


### PR DESCRIPTION
This adds a very quick validation that uploaded PDFs have some sort of text. The default threshold is 50 characters across the first 3 pages. If PDFs don't pass the check, they are rejected and a warning message is shown to the user:

<img width="1382" height="434" alt="image" src="https://github.com/user-attachments/assets/cae32e04-a3b3-49ad-8c8e-9a914310e986" />

Fixes #54