### PR TITLE
Add recommendation to a profile

### DIFF
--- a/django_site/core/templates/recommendations/list.html
+++ b/django_site/core/templates/recommendations/list.html
@@ -88,6 +88,7 @@
 </div>
 
 {# ── Result count ────────────────────────────────────── #}
+{% csrf_token %}
 <p class="text-sm text-dim" style="margin-bottom:.75rem;" id="result-count"></p>
 
 {# ── Results container ───────────────────────────────── #}
@@ -106,10 +107,14 @@
 const ALL_RECS = JSON.parse('{{ recs_json|escapejs }}');
 const CATEGORIES = JSON.parse('{{ categories_json|escapejs }}');
 const CODE_TO_LABEL = JSON.parse('{{ code_to_label_json|escapejs }}');
+const PROFILES = JSON.parse('{{ profiles_json|escapejs }}');
 const PROFILE_PARAM = '{{ profile_param }}';
+const SELECTED_PROFILE_ID = {{ selected_profile.pk|default:'null' }};
+const ADD_URL_BASE = '{% url "recommendations" %}add/';
 const PER_PAGE = 20;
 
 let currentPage = 1;
+const addedPapers = new Set();  /* track papers added during this session */
 
 /* ── Date helpers ──────────────────────────────────── */
 function isoDate(d) {
@@ -304,6 +309,33 @@ function renderCard(r, showDate) {
       + '" target="_blank" rel="noopener noreferrer" class="btn btn-sm mt-1">View on arXiv →</a>';
   }
 
+  /* "Add to Profile" button or dropdown */
+  if (r.paper_id) {
+    const paperId = r.paper_id;
+    const isAdded = addedPapers.has(paperId);
+    if (SELECTED_PROFILE_ID) {
+      /* single profile selected: one-click button */
+      html += ' <button class="btn btn-sm mt-1" id="add-btn-' + paperId + '"'
+        + (isAdded ? ' disabled style="opacity:.5;"' : '')
+        + ' onclick="addToProfile(' + SELECTED_PROFILE_ID + ',' + paperId + ')">' 
+        + (isAdded ? '✓ Added' : '+ Add to Profile') + '</button>';
+    } else {
+      /* all profiles: dropdown */
+      html += ' <span class="mt-1" style="display:inline-flex; align-items:center; gap:.3rem;" id="add-btn-' + paperId + '">';
+      if (isAdded) {
+        html += '<button class="btn btn-sm" disabled style="opacity:.5;">✓ Added</button>';
+      } else {
+        html += '<select class="btn btn-sm" style="padding:0.25rem 0.4rem;" onchange="if(this.value) addToProfile(+this.value,' + paperId + ')">';
+        html += '<option value="">+ Add to…</option>';
+        PROFILES.forEach(p => {
+          html += '<option value="' + p.id + '">' + esc(p.name) + '</option>';
+        });
+        html += '</select>';
+      }
+      html += '</span>';
+    }
+  }
+
   html += '</div>';
   return html;
 }
@@ -423,6 +455,52 @@ function restoreFromURL() {
   } else if (df === MONTH_AGO && dt === TODAY) {
     document.querySelector('.date-preset[data-preset="month"]').classList.add('active');
   }
+}
+
+/* ── Add recommendation to profile (AJAX) ─────────── */
+function addToProfile(profileId, paperId) {
+  const btn = document.getElementById('add-btn-' + paperId);
+  if (!btn) return;
+
+  /* show loading state */
+  const origHtml = btn.innerHTML;
+  if (btn.tagName === 'BUTTON') {
+    btn.disabled = true;
+    btn.textContent = 'Adding…';
+  } else {
+    /* span wrapper around dropdown */
+    btn.innerHTML = '<button class="btn btn-sm" disabled>Adding…</button>';
+  }
+
+  const csrf = document.querySelector('[name=csrfmiddlewaretoken]');
+  fetch(ADD_URL_BASE + profileId + '/' + paperId + '/', {
+    method: 'POST',
+    headers: {
+      'X-Requested-With': 'XMLHttpRequest',
+      'X-CSRFToken': csrf ? csrf.value : '',
+    },
+  })
+  .then(r => r.json())
+  .then(data => {
+    if (data.ok) {
+      addedPapers.add(paperId);
+      if (btn.tagName === 'BUTTON') {
+        btn.textContent = '✓ Added';
+        btn.disabled = true;
+        btn.style.opacity = '.5';
+      } else {
+        btn.innerHTML = '<button class="btn btn-sm" disabled style="opacity:.5;">✓ Added</button>';
+      }
+    } else {
+      /* restore original state on failure */
+      btn.innerHTML = origHtml;
+      if (btn.tagName === 'BUTTON') btn.disabled = false;
+    }
+  })
+  .catch(() => {
+    btn.innerHTML = origHtml;
+    if (btn.tagName === 'BUTTON') btn.disabled = false;
+  });
 }
 
 /* ── Wire up live filter events ───────────────────── */

--- a/django_site/core/templates/recommendations/list.html
+++ b/django_site/core/templates/recommendations/list.html
@@ -114,7 +114,7 @@ const ADD_URL_BASE = '{% url "recommendations" %}add/';
 const PER_PAGE = 20;
 
 let currentPage = 1;
-const addedPapers = new Set();  /* track papers added during this session */
+const addedPapers = new Map();  /* paperId → Set of profileIds added this session */
 
 /* ── Date helpers ──────────────────────────────────── */
 function isoDate(d) {
@@ -312,9 +312,11 @@ function renderCard(r, showDate) {
   /* "Add to Profile" button or dropdown */
   if (r.paper_id) {
     const paperId = r.paper_id;
-    const isAdded = addedPapers.has(paperId);
-    const inCorpus = r.in_corpus;
-    if (SELECTED_PROFILE_ID && (inCorpus || isAdded)) {
+    const inCorpusIds = r.in_corpus || [];
+    const sessionIds = addedPapers.get(paperId) || new Set();
+    /* combined set of profile IDs where this paper already exists */
+    const allLinked = new Set([...inCorpusIds, ...sessionIds]);
+    if (SELECTED_PROFILE_ID && allLinked.has(SELECTED_PROFILE_ID)) {
       /* already in this profile's corpus — show disabled indicator */
       html += ' <button class="btn btn-sm mt-1" disabled style="opacity:.5;">✓ In Profile</button>';
     } else if (SELECTED_PROFILE_ID) {
@@ -323,14 +325,9 @@ function renderCard(r, showDate) {
         + ' onclick="addToProfile(' + SELECTED_PROFILE_ID + ',' + paperId + ')">' 
         + '+ Add to Profile</button>';
     } else {
-      /* all profiles: dropdown */
+      /* all profiles: dropdown with per-profile disabled state */
       html += ' <span class="mt-1" style="display:inline-flex; align-items:center; gap:.3rem;" id="add-btn-' + paperId + '">';
-      html += '<select class="btn btn-sm" style="padding:0.25rem 0.4rem;" onchange="if(this.value) addToProfile(+this.value,' + paperId + ')">';
-      html += '<option value="">+ Add to…</option>';
-      PROFILES.forEach(p => {
-        html += '<option value="' + p.id + '">' + esc(p.name) + '</option>';
-      });
-      html += '</select>';
+      html += buildProfileDropdown(paperId, allLinked);
       html += '</span>';
     }
   }
@@ -456,6 +453,19 @@ function restoreFromURL() {
   }
 }
 
+/* ── Build profile dropdown for a paper ─────────── */
+function buildProfileDropdown(paperId, linkedIds) {
+  let html = '<select class="btn btn-sm" style="padding:0.25rem 0.4rem;" onchange="if(this.value) addToProfile(+this.value,' + paperId + ')">';
+  html += '<option value="">+ Add to…</option>';
+  PROFILES.forEach(p => {
+    const alreadyIn = linkedIds.has(p.id);
+    html += '<option value="' + p.id + '"' + (alreadyIn ? ' disabled' : '') + '>'
+      + esc(p.name) + (alreadyIn ? ' (✓)' : '') + '</option>';
+  });
+  html += '</select>';
+  return html;
+}
+
 /* ── Add recommendation to profile (AJAX) ─────────── */
 function addToProfile(profileId, paperId) {
   const btn = document.getElementById('add-btn-' + paperId);
@@ -482,19 +492,29 @@ function addToProfile(profileId, paperId) {
   .then(r => r.json())
   .then(data => {
     if (data.ok) {
+      /* track this addition */
+      if (!addedPapers.has(paperId)) addedPapers.set(paperId, new Set());
+      addedPapers.get(paperId).add(profileId);
+
       if (SELECTED_PROFILE_ID) {
         /* single profile: permanently disable */
-        addedPapers.add(paperId);
         if (btn.tagName === 'BUTTON') {
           btn.textContent = '✓ In Profile';
           btn.disabled = true;
           btn.style.opacity = '.5';
         }
       } else {
-        /* all profiles: briefly confirm, then reset dropdown */
+        /* all profiles: briefly confirm, then rebuild dropdown with updated disabled state */
         const profileName = PROFILES.find(p => p.id === profileId);
         btn.innerHTML = '<span class="text-sm" style="color:var(--success);">✓ Added to ' + esc(profileName ? profileName.name : 'profile') + '</span>';
-        setTimeout(() => { btn.innerHTML = origHtml; }, 2000);
+        setTimeout(() => {
+          /* find the rec data to get server-side in_corpus list */
+          const rec = ALL_RECS.find(r => r.paper_id === paperId);
+          const inCorpusIds = rec ? (rec.in_corpus || []) : [];
+          const sessionIds = addedPapers.get(paperId) || new Set();
+          const allLinked = new Set([...inCorpusIds, ...sessionIds]);
+          btn.innerHTML = buildProfileDropdown(paperId, allLinked);
+        }, 2000);
       }
     } else {
       btn.innerHTML = origHtml;

--- a/django_site/core/templates/recommendations/list.html
+++ b/django_site/core/templates/recommendations/list.html
@@ -313,25 +313,24 @@ function renderCard(r, showDate) {
   if (r.paper_id) {
     const paperId = r.paper_id;
     const isAdded = addedPapers.has(paperId);
-    if (SELECTED_PROFILE_ID) {
+    const inCorpus = r.in_corpus;
+    if (SELECTED_PROFILE_ID && (inCorpus || isAdded)) {
+      /* already in this profile's corpus — show disabled indicator */
+      html += ' <button class="btn btn-sm mt-1" disabled style="opacity:.5;">✓ In Profile</button>';
+    } else if (SELECTED_PROFILE_ID) {
       /* single profile selected: one-click button */
       html += ' <button class="btn btn-sm mt-1" id="add-btn-' + paperId + '"'
-        + (isAdded ? ' disabled style="opacity:.5;"' : '')
         + ' onclick="addToProfile(' + SELECTED_PROFILE_ID + ',' + paperId + ')">' 
-        + (isAdded ? '✓ Added' : '+ Add to Profile') + '</button>';
+        + '+ Add to Profile</button>';
     } else {
       /* all profiles: dropdown */
       html += ' <span class="mt-1" style="display:inline-flex; align-items:center; gap:.3rem;" id="add-btn-' + paperId + '">';
-      if (isAdded) {
-        html += '<button class="btn btn-sm" disabled style="opacity:.5;">✓ Added</button>';
-      } else {
-        html += '<select class="btn btn-sm" style="padding:0.25rem 0.4rem;" onchange="if(this.value) addToProfile(+this.value,' + paperId + ')">';
-        html += '<option value="">+ Add to…</option>';
-        PROFILES.forEach(p => {
-          html += '<option value="' + p.id + '">' + esc(p.name) + '</option>';
-        });
-        html += '</select>';
-      }
+      html += '<select class="btn btn-sm" style="padding:0.25rem 0.4rem;" onchange="if(this.value) addToProfile(+this.value,' + paperId + ')">';
+      html += '<option value="">+ Add to…</option>';
+      PROFILES.forEach(p => {
+        html += '<option value="' + p.id + '">' + esc(p.name) + '</option>';
+      });
+      html += '</select>';
       html += '</span>';
     }
   }
@@ -483,16 +482,21 @@ function addToProfile(profileId, paperId) {
   .then(r => r.json())
   .then(data => {
     if (data.ok) {
-      addedPapers.add(paperId);
-      if (btn.tagName === 'BUTTON') {
-        btn.textContent = '✓ Added';
-        btn.disabled = true;
-        btn.style.opacity = '.5';
+      if (SELECTED_PROFILE_ID) {
+        /* single profile: permanently disable */
+        addedPapers.add(paperId);
+        if (btn.tagName === 'BUTTON') {
+          btn.textContent = '✓ In Profile';
+          btn.disabled = true;
+          btn.style.opacity = '.5';
+        }
       } else {
-        btn.innerHTML = '<button class="btn btn-sm" disabled style="opacity:.5;">✓ Added</button>';
+        /* all profiles: briefly confirm, then reset dropdown */
+        const profileName = PROFILES.find(p => p.id === profileId);
+        btn.innerHTML = '<span class="text-sm" style="color:var(--success);">✓ Added to ' + esc(profileName ? profileName.name : 'profile') + '</span>';
+        setTimeout(() => { btn.innerHTML = origHtml; }, 2000);
       }
     } else {
-      /* restore original state on failure */
       btn.innerHTML = origHtml;
       if (btn.tagName === 'BUTTON') btn.disabled = false;
     }

--- a/django_site/core/urls.py
+++ b/django_site/core/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
 
     # Recommendations
     path("recommendations/", views.recommendations_view, name="recommendations"),
+    path("recommendations/add/<int:profile_id>/<int:paper_id>/", views.recommendation_add_to_profile_view, name="recommendation_add_to_profile"),
 
     # Settings
     path("settings/", views.settings_view, name="settings"),

--- a/django_site/core/views.py
+++ b/django_site/core/views.py
@@ -1224,12 +1224,14 @@ def _query_profile_recommendations(pb_user, profile=None):
         for s in Summary.objects.filter(paper_id__in=paper_ids, mode="abstract")
     }
 
-    # Check which recommended papers are already in the user's corpus
-    corpus_paper_ids = set()
+    # Check which recommended papers are already in each profile's corpus
+    profile_paper_ids = {}  # {profile_id: set of paper_ids}
     for c in user_corpora:
-        corpus_paper_ids.update(
-            Paper.objects.filter(corpora=c).values_list("pk", flat=True)
-        )
+        pid = corpus_to_profile.get(c.pk)
+        if pid:
+            profile_paper_ids[pid] = set(
+                Paper.objects.filter(corpora=c).values_list("pk", flat=True)
+            )
 
     # Deduplicate by arxiv_id keeping highest score
     seen = {}
@@ -1246,7 +1248,10 @@ def _query_profile_recommendations(pb_user, profile=None):
         seen[aid] = {
             "paper_id": paper.pk,
             "profile_id": corpus_to_profile.get(rec.run.user_corpus_id),
-            "in_corpus": paper.pk in corpus_paper_ids,
+            "in_corpus": [
+                prof_id for prof_id, paper_set in profile_paper_ids.items()
+                if paper.pk in paper_set
+            ],
             "title": paper.title,
             "score": rec.score,
             "rank": rec.rank,

--- a/django_site/core/views.py
+++ b/django_site/core/views.py
@@ -1201,14 +1201,14 @@ def _query_profile_recommendations(pb_user, profile=None):
     # Get runs that used any of these corpora
     runs = RecommendationRun.objects.filter(user_corpus__in=user_corpora)
 
-    # Build a mapping from corpus ID to profile ID for tagging recommendations
+    # Build a mapping from corpus ID to profile ID by parsing corpus names
     corpus_to_profile = {}
-    for p in Profile.objects.filter(user=pb_user):
-        cname = f"user_{pb_user.pk}_profile_{p.pk}"
-        for c in user_corpora:
-            if c.name == cname:
-                corpus_to_profile[c.pk] = p.pk
-                break
+    profile_prefix = f"user_{pb_user.pk}_profile_"
+    for c in user_corpora:
+        if c.name.startswith(profile_prefix):
+            profile_id_str = c.name[len(profile_prefix):]
+            if profile_id_str.isdigit():
+                corpus_to_profile[c.pk] = int(profile_id_str)
 
     recs_list = list(
         Recommendation.objects.filter(run__in=runs)
@@ -1225,13 +1225,14 @@ def _query_profile_recommendations(pb_user, profile=None):
     }
 
     # Check which recommended papers are already in each profile's corpus
+    # (restricted to paper_ids in this batch for efficiency)
     profile_paper_ids = {}  # {profile_id: set of paper_ids}
-    for c in user_corpora:
-        pid = corpus_to_profile.get(c.pk)
+    for paper_pk, corpus_pk in Paper.objects.filter(
+        pk__in=paper_ids, corpora__in=user_corpora
+    ).values_list("pk", "corpora__pk"):
+        pid = corpus_to_profile.get(corpus_pk)
         if pid:
-            profile_paper_ids[pid] = set(
-                Paper.objects.filter(corpora=c).values_list("pk", flat=True)
-            )
+            profile_paper_ids.setdefault(pid, set()).add(paper_pk)
 
     # Deduplicate by arxiv_id keeping highest score
     seen = {}
@@ -1278,6 +1279,14 @@ def recommendation_add_to_profile_view(request, profile_id, paper_id):
     pb_user = request.pb_user
     profile = get_object_or_404(Profile, pk=profile_id, user=pb_user)
     paper = get_object_or_404(Paper, pk=paper_id)
+
+    # Verify the paper was actually recommended to this user
+    was_recommended = Recommendation.objects.filter(
+        paper=paper, run__user=pb_user
+    ).exists()
+    if not was_recommended:
+        return JsonResponse({"ok": False, "error": "Paper not found."}, status=404)
+
     corpus = _get_or_create_user_corpus(pb_user, profile)
 
     already_linked = paper.corpora.filter(pk=corpus.pk).exists()

--- a/django_site/core/views.py
+++ b/django_site/core/views.py
@@ -1246,6 +1246,7 @@ def _query_profile_recommendations(pb_user, profile=None):
         seen[aid] = {
             "paper_id": paper.pk,
             "profile_id": corpus_to_profile.get(rec.run.user_corpus_id),
+            "in_corpus": paper.pk in corpus_paper_ids,
             "title": paper.title,
             "score": rec.score,
             "rank": rec.rank,

--- a/django_site/core/views.py
+++ b/django_site/core/views.py
@@ -1171,6 +1171,9 @@ def recommendations_view(request):
         "recs_json": json.dumps(recs),
         "categories_json": json.dumps(profile_categories),
         "code_to_label_json": json.dumps(ARXIV_CODE_TO_LABEL),
+        "profiles_json": json.dumps([
+            {"id": p.pk, "name": p.name} for p in profiles
+        ]),
     })
 
 
@@ -1197,6 +1200,16 @@ def _query_profile_recommendations(pb_user, profile=None):
 
     # Get runs that used any of these corpora
     runs = RecommendationRun.objects.filter(user_corpus__in=user_corpora)
+
+    # Build a mapping from corpus ID to profile ID for tagging recommendations
+    corpus_to_profile = {}
+    for p in Profile.objects.filter(user=pb_user):
+        cname = f"user_{pb_user.pk}_profile_{p.pk}"
+        for c in user_corpora:
+            if c.name == cname:
+                corpus_to_profile[c.pk] = p.pk
+                break
+
     recs_list = list(
         Recommendation.objects.filter(run__in=runs)
         .select_related("paper", "run")
@@ -1211,6 +1224,13 @@ def _query_profile_recommendations(pb_user, profile=None):
         for s in Summary.objects.filter(paper_id__in=paper_ids, mode="abstract")
     }
 
+    # Check which recommended papers are already in the user's corpus
+    corpus_paper_ids = set()
+    for c in user_corpora:
+        corpus_paper_ids.update(
+            Paper.objects.filter(corpora=c).values_list("pk", flat=True)
+        )
+
     # Deduplicate by arxiv_id keeping highest score
     seen = {}
     for rec in recs_list:
@@ -1224,6 +1244,8 @@ def _query_profile_recommendations(pb_user, profile=None):
         date_str = dt.strftime("%d %B %Y") if dt else "Unknown Date"
 
         seen[aid] = {
+            "paper_id": paper.pk,
+            "profile_id": corpus_to_profile.get(rec.run.user_corpus_id),
             "title": paper.title,
             "score": rec.score,
             "rank": rec.rank,
@@ -1237,6 +1259,35 @@ def _query_profile_recommendations(pb_user, profile=None):
         }
 
     return list(seen.values())
+
+
+@pbuser_required
+@require_POST
+def recommendation_add_to_profile_view(request, profile_id, paper_id):
+    """Add a recommended paper to a profile's corpus (AJAX).
+
+    Unlike paper_add_arxiv_view, this doesn't download anything — the paper
+    already exists in the DB from the pipeline.
+    """
+    pb_user = request.pb_user
+    profile = get_object_or_404(Profile, pk=profile_id, user=pb_user)
+    paper = get_object_or_404(Paper, pk=paper_id)
+    corpus = _get_or_create_user_corpus(pb_user, profile)
+
+    already_linked = paper.corpora.filter(pk=corpus.pk).exists()
+    if already_linked:
+        return JsonResponse({"ok": True, "already_linked": True})
+
+    _link_paper_to_corpus(paper, corpus)
+    return JsonResponse({
+        "ok": True,
+        "already_linked": False,
+        "paper": {
+            "id": paper.pk,
+            "title": paper.title,
+            "arxiv_id": paper.arxiv_id,
+        },
+    })
 
 
 # ── Settings ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
This adds a button/dropdown to the recommendations pages allowing users to add a recommendation to a profile. Since the papers are already downloaded from the pipeline, linking them to the profile is extremely fast.

As papers are added to the profile, the interactable elements are disabled. On page load, already added papers have disabled buttons/`<option>`s.

**All profiles recommendations page:**
<img width="734" height="567" alt="image" src="https://github.com/user-attachments/assets/219434c0-f256-4ddf-9cb4-712a7f838834" />

**Individual profile recommendations page:**
<img width="758" height="550" alt="image" src="https://github.com/user-attachments/assets/a009a099-2271-4545-84b5-b634c8ed694e" />

Fixes #50 