### PR TITLE
Enforce one recommendation per profile+paper

### DIFF
--- a/django_site/core/migrations/0011_recommendation_profile_id.py
+++ b/django_site/core/migrations/0011_recommendation_profile_id.py
@@ -32,6 +32,17 @@ def backfill_profile_and_dedupe(apps, schema_editor):
 
         # 2. Drop orphans: recommendations whose run has no profile.
         # These can't satisfy the new (profile, paper) constraint.
+        # Django's on_delete=CASCADE is enforced by the ORM, not at the DB
+        # layer, so the underlying FK from profile_recommendations is
+        # NO ACTION — we have to delete junction rows ourselves first.
+        cur.execute(
+            """
+            DELETE FROM profile_recommendations
+            WHERE recommendation_id IN (
+                SELECT id FROM recommendations WHERE profile_id IS NULL
+            )
+            """
+        )
         cur.execute(
             "DELETE FROM recommendations WHERE profile_id IS NULL"
         )
@@ -59,8 +70,24 @@ def backfill_profile_and_dedupe(apps, schema_editor):
         )
 
         # 4. Delete the duplicate losers (everything except the highest run_id
-        # row in each (profile, paper) group). profile_recommendations rows
-        # cascade automatically via the FK.
+        # row in each (profile, paper) group). Junction rows in
+        # profile_recommendations don't cascade at the DB level (see note
+        # above), so remove them first by the same loser-selection rule.
+        cur.execute(
+            """
+            DELETE FROM profile_recommendations pr
+            USING recommendations r,
+                  (
+                      SELECT profile_id, paper_id, MAX(run_id) AS keep_run_id
+                      FROM recommendations
+                      GROUP BY profile_id, paper_id
+                  ) keepers
+            WHERE pr.recommendation_id = r.id
+              AND r.profile_id = keepers.profile_id
+              AND r.paper_id   = keepers.paper_id
+              AND r.run_id    <> keepers.keep_run_id
+            """
+        )
         cur.execute(
             """
             DELETE FROM recommendations r
@@ -74,11 +101,6 @@ def backfill_profile_and_dedupe(apps, schema_editor):
               AND r.run_id    <> keepers.keep_run_id
             """
         )
-
-
-def reverse_backfill(apps, schema_editor):
-    """Cannot reverse — deduped duplicates and orphans are gone for good."""
-    pass
 
 
 class Migration(migrations.Migration):
@@ -102,7 +124,13 @@ class Migration(migrations.Migration):
             ),
         ),
         # Step 2: backfill, drop orphans, and dedupe.
-        migrations.RunPython(backfill_profile_and_dedupe, reverse_backfill),
+        # Reverse is RunPython.noop: the schema rollback (DROP COLUMN etc.)
+        # via the surrounding operations is fine, but the deleted duplicate
+        # and orphan rows are gone for good and won't be restored.
+        migrations.RunPython(
+            backfill_profile_and_dedupe,
+            migrations.RunPython.noop,
+        ),
         # Step 3: every surviving row has a profile, so make the FK required.
         migrations.AlterField(
             model_name="recommendation",

--- a/django_site/core/migrations/0011_recommendation_profile_id.py
+++ b/django_site/core/migrations/0011_recommendation_profile_id.py
@@ -1,0 +1,123 @@
+# Generated for preprint-bot v1.1
+# Enforce one recommendation per (profile, paper) to prevent duplicate
+# digest emails when the pipeline is re-run for the same profile.
+
+from django.db import migrations, models
+
+
+def backfill_profile_and_dedupe(apps, schema_editor):
+    """Backfill recommendations.profile_id from the parent run, then dedupe
+    so each (profile, paper) pair has exactly one row.
+
+    Dedupe rule: keep the row with the highest run_id (most recent run).
+    Before deleting, OR-propagate ``sent_in_email`` across all duplicates
+    onto the kept row so a paper that was already emailed in *any*
+    duplicate stays marked as sent and isn't re-emailed.
+
+    Recommendations whose parent run has a NULL profile_id are orphaned
+    under the new model (a recommendation must belong to a profile);
+    those are deleted outright.
+    """
+    with schema_editor.connection.cursor() as cur:
+        # 1. Backfill profile_id from the parent recommendation_run.
+        cur.execute(
+            """
+            UPDATE recommendations r
+            SET profile_id = rr.profile_id
+            FROM recommendation_runs rr
+            WHERE r.run_id = rr.id
+              AND r.profile_id IS NULL
+            """
+        )
+
+        # 2. Drop orphans: recommendations whose run has no profile.
+        # These can't satisfy the new (profile, paper) constraint.
+        cur.execute(
+            "DELETE FROM recommendations WHERE profile_id IS NULL"
+        )
+
+        # 3. For each duplicated (profile, paper), propagate sent_in_email
+        # onto the row we're going to keep (the one with the highest run_id).
+        cur.execute(
+            """
+            WITH agg AS (
+                SELECT profile_id,
+                       paper_id,
+                       BOOL_OR(sent_in_email) AS any_sent,
+                       MAX(run_id)            AS keep_run_id
+                FROM recommendations
+                GROUP BY profile_id, paper_id
+                HAVING COUNT(*) > 1
+            )
+            UPDATE recommendations r
+            SET sent_in_email = agg.any_sent
+            FROM agg
+            WHERE r.profile_id = agg.profile_id
+              AND r.paper_id   = agg.paper_id
+              AND r.run_id     = agg.keep_run_id
+            """
+        )
+
+        # 4. Delete the duplicate losers (everything except the highest run_id
+        # row in each (profile, paper) group). profile_recommendations rows
+        # cascade automatically via the FK.
+        cur.execute(
+            """
+            DELETE FROM recommendations r
+            USING (
+                SELECT profile_id, paper_id, MAX(run_id) AS keep_run_id
+                FROM recommendations
+                GROUP BY profile_id, paper_id
+            ) keepers
+            WHERE r.profile_id = keepers.profile_id
+              AND r.paper_id   = keepers.paper_id
+              AND r.run_id    <> keepers.keep_run_id
+            """
+        )
+
+
+def reverse_backfill(apps, schema_editor):
+    """Cannot reverse — deduped duplicates and orphans are gone for good."""
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0010_merge_20260508_1148"),
+    ]
+
+    operations = [
+        # Step 1: add the FK as nullable so we can populate it before
+        # enforcing NOT NULL.
+        migrations.AddField(
+            model_name="recommendation",
+            name="profile",
+            field=models.ForeignKey(
+                to="core.profile",
+                on_delete=models.deletion.CASCADE,
+                related_name="recommendations",
+                blank=True,
+                null=True,
+            ),
+        ),
+        # Step 2: backfill, drop orphans, and dedupe.
+        migrations.RunPython(backfill_profile_and_dedupe, reverse_backfill),
+        # Step 3: every surviving row has a profile, so make the FK required.
+        migrations.AlterField(
+            model_name="recommendation",
+            name="profile",
+            field=models.ForeignKey(
+                to="core.profile",
+                on_delete=models.deletion.CASCADE,
+                related_name="recommendations",
+            ),
+        ),
+        # Step 4: enforce one recommendation per (profile, paper).
+        # The existing (run, paper) constraint is preserved as a redundant
+        # but cheap intra-run invariant.
+        migrations.AlterUniqueTogether(
+            name="recommendation",
+            unique_together={("run", "paper"), ("profile", "paper")},
+        ),
+    ]

--- a/django_site/core/models.py
+++ b/django_site/core/models.py
@@ -305,6 +305,10 @@ class Recommendation(models.Model):
     run = models.ForeignKey(
         RecommendationRun, on_delete=models.CASCADE, related_name="recommendations"
     )
+    # Denormalized from run.profile to enforce a DB-level uniqueness
+    # constraint of one recommendation per (profile, paper). Backfilled in
+    # migration 0011; always equals self.run.profile by construction.
+    profile = models.ForeignKey(Profile, on_delete=models.CASCADE, related_name="recommendations")
     paper = models.ForeignKey(Paper, on_delete=models.CASCADE, related_name="recommendations")
     score = models.FloatField()
     rank = models.IntegerField()
@@ -314,7 +318,11 @@ class Recommendation(models.Model):
 
     class Meta:
         db_table = "recommendations"
-        unique_together = [("run", "paper")]
+        # (profile, paper) is the primary invariant: one recommendation per
+        # paper per profile, ever. (run, paper) is kept as a redundant
+        # intra-run invariant — implied by (profile, paper) since each run
+        # has one profile, but explicit and cheap.
+        unique_together = [("run", "paper"), ("profile", "paper")]
         indexes = [
             models.Index(fields=["sent_in_email"], name="recommendations_sent_idx"),
         ]

--- a/routes/recommendations.py
+++ b/routes/recommendations.py
@@ -13,39 +13,63 @@ async def create_recommendation(rec: RecommendationCreate):
     try:
         async with pool.acquire() as conn:
             async with conn.transaction():
+                # Resolve the run's profile_id up front. Every recommendation
+                # must belong to a profile under the (profile, paper)
+                # uniqueness model; a run without one can't produce valid
+                # recommendations.
+                run_row = await conn.fetchrow(
+                    "SELECT profile_id FROM recommendation_runs WHERE id = $1",
+                    rec.run_id,
+                )
+                if not run_row:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"recommendation_run {rec.run_id} not found",
+                    )
+                if run_row["profile_id"] is None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Run has no profile_id; cannot create recommendation",
+                    )
+                profile_id = run_row["profile_id"]
+
+                # Insert the recommendation. On conflict with an existing
+                # (profile, paper) row, do nothing — the original row (and
+                # its sent_in_email flag) stays as-is. This is what prevents
+                # the same paper from being re-emailed across re-runs.
                 row = await conn.fetchrow(
                     """
                     WITH ins AS (
-                        INSERT INTO recommendations (run_id, paper_id, score, rank, summary)
-                        VALUES ($1, $2, $3, $4, $5)
-                        ON CONFLICT (run_id, paper_id) DO UPDATE
-                            SET score = EXCLUDED.score,
-                                rank = EXCLUDED.rank,
-                                summary = EXCLUDED.summary
+                        INSERT INTO recommendations
+                            (run_id, profile_id, paper_id, score, rank, summary)
+                        VALUES ($1, $2, $3, $4, $5, $6)
+                        ON CONFLICT (profile_id, paper_id) DO NOTHING
                         RETURNING id, run_id, paper_id, score, rank, summary, created_at
                     )
                     INSERT INTO profile_recommendations (profile_id, recommendation_id)
-                    SELECT rr.profile_id, ins.id
-                    FROM recommendation_runs rr, ins
-                    WHERE rr.id = $1
+                    SELECT $2, ins.id FROM ins
                     ON CONFLICT DO NOTHING
                     RETURNING (SELECT id FROM ins), (SELECT run_id FROM ins),
                               (SELECT paper_id FROM ins), (SELECT score FROM ins),
                               (SELECT rank FROM ins), (SELECT summary FROM ins),
                               (SELECT created_at FROM ins)
                     """,
-                    rec.run_id, rec.paper_id, rec.score, rec.rank, rec.summary
+                    rec.run_id, profile_id, rec.paper_id,
+                    rec.score, rec.rank, rec.summary,
                 )
                 if not row:
-                    # profile_recommendations already existed (ON CONFLICT DO NOTHING
-                    # returned nothing) — fetch the upserted recommendation directly
+                    # Either the recommendation already existed (conflict on
+                    # profile_id, paper_id) and DO NOTHING returned no row,
+                    # or the profile_recommendations row already existed.
+                    # Fetch the surviving recommendation by its real key.
                     row = await conn.fetchrow(
                         """SELECT id, run_id, paper_id, score, rank, summary, created_at
-                           FROM recommendations WHERE run_id = $1 AND paper_id = $2""",
-                        rec.run_id, rec.paper_id
+                           FROM recommendations
+                           WHERE profile_id = $1 AND paper_id = $2""",
+                        profile_id, rec.paper_id,
                     )
                 if not row:
-                    raise HTTPException(status_code=400, detail="Insert failed — profile_id may be missing on run")
+                    raise HTTPException(status_code=400, detail="Insert failed")
                 return dict(row)
     except HTTPException:
         raise


### PR DESCRIPTION
- Add database-level constraint
- Add data migration, including deduplication
- Add dupe handling to API recommendations route


Fixes #80