### PR TITLE
Author names everywhere

### DIFF
--- a/django_site/core/migrations/0012_split_author_lists.py
+++ b/django_site/core/migrations/0012_split_author_lists.py
@@ -1,0 +1,76 @@
+"""
+Split comma-joined author strings in papers.metadata into proper lists.
+
+arXiv's RSS feed delivers all authors in a single ``<dc:creator>`` element
+as one comma-separated string. Before the fix to ``_parse_rss_authors``,
+feedparser's one-element ``item.authors`` list was stored verbatim, so
+affected papers have::
+
+    metadata["authors"] == ["Alice Smith, Bob Jones, Carol Lee"]   (1 element)
+
+instead of::
+
+    metadata["authors"] == ["Alice Smith", "Bob Jones", "Carol Lee"]
+
+This migration finds those rows and splits the single string into a proper
+list, matching what the corrected pipeline now produces. Papers fetched via
+the arXiv API path (which always produced correct lists) are left alone.
+"""
+
+from django.db import migrations
+
+
+def _needs_split(authors):
+    """True if ``authors`` is a single comma-joined string in a 1-element list."""
+    return (
+        isinstance(authors, list)
+        and len(authors) == 1
+        and isinstance(authors[0], str)
+        and "," in authors[0]
+    )
+
+
+def split_author_lists(apps, schema_editor):
+    """Rewrite affected metadata["authors"] in place."""
+    Paper = apps.get_model("core", "Paper")
+
+    fixed = 0
+    # iterator() keeps memory flat over a large papers table.
+    for paper in Paper.objects.iterator():
+        metadata = paper.metadata
+        if not isinstance(metadata, dict):
+            continue
+        authors = metadata.get("authors")
+        if not _needs_split(authors):
+            continue
+
+        new_authors = [a.strip() for a in authors[0].split(",") if a.strip()]
+        # Only a fix if the split actually yields more than one name.
+        if len(new_authors) <= 1:
+            continue
+
+        metadata["authors"] = new_authors
+        paper.metadata = metadata
+        paper.save(update_fields=["metadata"])
+        fixed += 1
+
+    if fixed:
+        print(f"  Split author lists for {fixed} paper(s).")
+    else:
+        print("  No affected rows found.")
+
+
+def reverse_noop(apps, schema_editor):
+    """Split authors are always better; no reason to revert."""
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0011_recommendation_profile_id"),
+    ]
+
+    operations = [
+        migrations.RunPython(split_author_lists, reverse_noop),
+    ]

--- a/django_site/core/migrations/0012_split_author_lists.py
+++ b/django_site/core/migrations/0012_split_author_lists.py
@@ -40,6 +40,10 @@ def split_author_lists(apps, schema_editor):
         metadata = paper.metadata
         if not isinstance(metadata, dict):
             continue
+        # Only touch RSS-ingested rows (they carry announce_type). API-path
+        # rows are left alone.
+        if "announce_type" not in metadata:
+            continue
         authors = metadata.get("authors")
         if not _needs_split(authors):
             continue

--- a/django_site/core/models.py
+++ b/django_site/core/models.py
@@ -199,6 +199,12 @@ class Paper(models.Model):
             return self.metadata.get("categories", [])
         return []
 
+    @property
+    def authors_list(self):
+        if self.metadata and isinstance(self.metadata, dict):
+            return self.metadata.get("authors", [])
+        return []
+
 
 # ── Sections ───────────────────────────────────────────────────────────────
 

--- a/django_site/core/models.py
+++ b/django_site/core/models.py
@@ -201,8 +201,19 @@ class Paper(models.Model):
 
     @property
     def authors_list(self):
-        if self.metadata and isinstance(self.metadata, dict):
-            return self.metadata.get("authors", [])
+        """Authors from metadata, always as a list of strings.
+
+        Legacy/malformed rows may store ``authors`` as a bare string
+        instead of a list; normalize so templates (Django ``join``) and
+        the recommendations JS (``slice``/``join``) always receive a list.
+        """
+        if not (self.metadata and isinstance(self.metadata, dict)):
+            return []
+        authors = self.metadata.get("authors", [])
+        if isinstance(authors, list):
+            return authors
+        if isinstance(authors, str) and authors.strip():
+            return [authors]
         return []
 
 

--- a/django_site/core/templates/dashboard.html
+++ b/django_site/core/templates/dashboard.html
@@ -32,6 +32,12 @@
       <span class="score-badge">{{ rec.score|floatformat:3 }}</span>
     </div>
 
+    {% if rec.authors %}
+      <div class="text-sm text-dim" style="margin-top:.25rem;">
+        {{ rec.authors|slice:":25"|join:", " }}{% if rec.authors|length > 25 %} et al.{% endif %}
+      </div>
+    {% endif %}
+
     {% if rec.arxiv_id %}
       <span class="text-sm text-dim text-mono">{{ rec.arxiv_id }}</span>
     {% endif %}

--- a/django_site/core/templates/recommendations/list.html
+++ b/django_site/core/templates/recommendations/list.html
@@ -160,6 +160,13 @@ function catLabel(code) {
   return CODE_TO_LABEL[code] || code;
 }
 
+/* ── Format author list (match profile search: cap at 25 + et al.) ─ */
+function formatAuthors(authors) {
+  if (!authors || !authors.length) return '';
+  if (authors.length > 25) return authors.slice(0, 25).join(', ') + ' et al.';
+  return authors.join(', ');
+}
+
 /* ── Build category pill filters ──────────────────── */
 function buildCatFilters() {
   const container = document.getElementById('cat-pills');
@@ -287,6 +294,11 @@ function renderCard(r, showDate) {
     html += '<div style="margin-bottom:.35rem;">';
     r.categories.forEach(c => { html += '<span class="tag">' + esc(catLabel(c)) + '</span>'; });
     html += '</div>';
+  }
+
+  const authorsStr = formatAuthors(r.authors);
+  if (authorsStr) {
+    html += '<div class="text-sm text-dim" style="margin-bottom:.25rem;">' + esc(authorsStr) + '</div>';
   }
 
   if (showDate) {

--- a/django_site/core/views.py
+++ b/django_site/core/views.py
@@ -1306,6 +1306,7 @@ def _query_profile_recommendations(pb_user, profile=None):
             "date_obj": date_obj,
             "date_str": date_str,
             "categories": paper.categories_list,
+            "authors": paper.authors_list,
             "total_papers_fetched": rec.run.total_papers_fetched,
         }
 

--- a/routes/emails.py
+++ b/routes/emails.py
@@ -3,6 +3,7 @@ from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel
 from typing import Optional
 from datetime import date, datetime
+import json
 from database import get_db_pool
 from services.email_service import send_recommendations_digest, send_email
 
@@ -43,7 +44,7 @@ async def send_digest(req: DigestRequest):
         rows = await conn.fetch(
             """
             SELECT r.id AS recommendation_id,
-                   p.arxiv_id, p.title, p.abstract,
+                   p.arxiv_id, p.title, p.abstract, p.metadata,
                    r.score, r.summary, s.summary_text
             FROM recommendations r
             JOIN recommendation_runs rr ON rr.id = r.run_id
@@ -63,6 +64,16 @@ async def send_digest(req: DigestRequest):
         # Collect recommendation IDs for marking as sent
         rec_ids = [row["recommendation_id"] for row in rows]
         papers = [dict(r) for r in rows]
+
+    # Extract author lists from each paper's metadata
+    for paper in papers:
+        meta = paper.get("metadata")
+        if isinstance(meta, str):
+            try:
+                meta = json.loads(meta)
+            except (ValueError, TypeError):
+                meta = {}
+        paper["authors"] = meta.get("authors", []) if isinstance(meta, dict) else []
 
     frequency = profile["frequency"] or "daily"
 

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -21,6 +21,15 @@ def truncate_to_sentences(text: str, n: int = 3) -> tuple[str, bool]:
     return ' '.join(sentences[:n]), True
 
 
+def format_authors(authors: List[str], cap: int = 25) -> str:
+    """Join author names, capping at *cap* names with 'et al.'."""
+    if not authors:
+        return ""
+    if len(authors) > cap:
+        return ", ".join(authors[:cap]) + " et al."
+    return ", ".join(authors)
+
+
 def build_digest_html(profile_name: str, papers: List[Dict], run_date: str, shown: int, total: int, frequency: str = "daily") -> str:
     papers = papers[:10]
     rows = ""
@@ -28,17 +37,20 @@ def build_digest_html(profile_name: str, papers: List[Dict], run_date: str, show
         arxiv_id = paper.get("arxiv_id", "")
         title = paper.get("title", "No title")
         score = paper.get("score", 0)
+        authors = format_authors(paper.get("authors") or [])
         summary = paper.get("summary_text") or paper.get("summary") or paper.get("abstract", "")
         arxiv_url = f"https://arxiv.org/abs/{arxiv_id}" if arxiv_id else "#"
 
         truncated_summary, was_truncated = truncate_to_sentences(summary, 3)
         read_more = f' <a href="{DASHBOARD_URL}" style="color:{SU_ORANGE};font-size:12px;text-decoration:none;">Read more →</a>' if was_truncated else ''
 
+        authors_html = f'<br><span style="font-size:12px;color:#666;">{authors}</span>' if authors else ''
+
         rows += f"""
         <tr>
             <td style="padding:12px;border-bottom:1px solid #eee;vertical-align:top;width:30px;color:#888;">{i}</td>
             <td style="padding:12px;border-bottom:1px solid #eee;vertical-align:top;">
-                <a href="{arxiv_url}" style="font-size:15px;font-weight:bold;color:{SU_NAVY};text-decoration:none;">{title}</a>
+                <a href="{arxiv_url}" style="font-size:15px;font-weight:bold;color:{SU_NAVY};text-decoration:none;">{title}</a>{authors_html}
                 <br>
                 <span style="font-size:12px;color:#888;">Score: {score:.3f}</span>
                 <p style="margin:8px 0 0;font-size:13px;color:#444;">{truncated_summary}{read_more}</p>

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -1,6 +1,7 @@
 import smtplib
 import re
 import sys
+import html
 from pathlib import Path
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -44,7 +45,7 @@ def build_digest_html(profile_name: str, papers: List[Dict], run_date: str, show
         truncated_summary, was_truncated = truncate_to_sentences(summary, 3)
         read_more = f' <a href="{DASHBOARD_URL}" style="color:{SU_ORANGE};font-size:12px;text-decoration:none;">Read more →</a>' if was_truncated else ''
 
-        authors_html = f'<br><span style="font-size:12px;color:#666;">{authors}</span>' if authors else ''
+        authors_html = f'<br><span style="font-size:12px;color:#666;">{html.escape(authors)}</span>' if authors else ''
 
         rows += f"""
         <tr>

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -51,10 +51,10 @@ def build_digest_html(profile_name: str, papers: List[Dict], run_date: str, show
         <tr>
             <td style="padding:12px;border-bottom:1px solid #eee;vertical-align:top;width:30px;color:#888;">{i}</td>
             <td style="padding:12px;border-bottom:1px solid #eee;vertical-align:top;">
-                <a href="{arxiv_url}" style="font-size:15px;font-weight:bold;color:{SU_NAVY};text-decoration:none;">{title}</a>{authors_html}
+                <a href="{html.escape(arxiv_url)}" style="font-size:15px;font-weight:bold;color:{SU_NAVY};text-decoration:none;">{html.escape(title)}</a>{authors_html}
                 <br>
                 <span style="font-size:12px;color:#888;">Score: {score:.3f}</span>
-                <p style="margin:8px 0 0;font-size:13px;color:#444;">{truncated_summary}{read_more}</p>
+                <p style="margin:8px 0 0;font-size:13px;color:#444;">{html.escape(truncated_summary)}{read_more}</p>
             </td>
         </tr>
         """
@@ -68,10 +68,10 @@ def build_digest_html(profile_name: str, papers: List[Dict], run_date: str, show
     <div style="max-width:700px;margin:30px auto;background:#fff;border-radius:8px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.1);">
         <div style="background:{SU_NAVY};padding:24px 32px;">
             <h1 style="margin:0;font-size:22px;"><a href="{DASHBOARD_URL}" style="color:{SU_ORANGE};text-decoration:none;">Preprint Bot</a></h1>
-            <p style="color:#cce0ff;margin:4px 0 0;font-size:14px;">{header_label} Recommendations &mdash; {run_date}</p>
+            <p style="color:#cce0ff;margin:4px 0 0;font-size:14px;">{header_label} Recommendations &mdash; {html.escape(run_date)}</p>
         </div>
         <div style="padding:24px 32px;">
-            <p style="font-size:15px;color:#333;">Here are your top recommendations for profile <strong>{profile_name}</strong>:</p>
+            <p style="font-size:15px;color:#333;">Here are your top recommendations for profile <strong>{html.escape(profile_name)}</strong>:</p>
             <p style="font-size:13px;color:#888;margin-top:-8px;">{count_line}</p>
             <table style="width:100%;border-collapse:collapse;">
                 {rows}

--- a/src/preprint_bot/sources/arxiv.py
+++ b/src/preprint_bot/sources/arxiv.py
@@ -197,21 +197,23 @@ def _clean_html(text: str) -> str:
 def _parse_rss_authors(item) -> List[str]:
     """Extract author list from an RSS item.
 
-    The RSS feed uses ``<dc:creator>`` which feedparser exposes as
-    ``item.author`` (a comma-separated string) or ``item.authors``.
+    arXiv's RSS puts all authors in a single ``<dc:creator>`` element
+    as one comma-separated string.
     """
-    # feedparser may expose a list of author dicts
+    # Gather raw name strings from whichever field feedparser populated
+    raw: List[str] = []
     if hasattr(item, "authors") and item.authors:
-        names = [a.get("name", "") for a in item.authors if a.get("name")]
-        if names:
-            return names
+        raw = [a.get("name", "") for a in item.authors if a.get("name")]
+    if not raw:
+        author_str = getattr(item, "author", "")
+        if author_str:
+            raw = [author_str]
 
-    # Fall back to the comma-separated dc:creator string
-    author_str = getattr(item, "author", "")
-    if author_str:
-        return [a.strip() for a in author_str.split(",") if a.strip()]
-
-    return []
+    # Split any comma-joined entries into individual authors
+    names: List[str] = []
+    for entry in raw:
+        names.extend(a.strip() for a in entry.split(",") if a.strip())
+    return names
 
 
 def _parse_rss_categories(item) -> List[str]:


### PR DESCRIPTION
This adds authors names (like they are displayed in the arXiv paper search with a 25 author cap) to:

- the dashboard page
- the recommendations page(s)
- digest emails

Along the way, I also discovered that authors are delivered in the arXiv RSS as a single string and this was stored verbatim in the database. This PR adds a fix so that we split this before storing and a migration to split the author lists for papers that already exist in the database.

Most code was written by Claude and then manually reviewed and edited by me. I tested everything in my local development environment.

Fixes #88

On the recommendations page:
<img width="1358" height="406" alt="image" src="https://github.com/user-attachments/assets/f3a14054-f0b0-4ddf-8fa3-d3895e1aa20f" />

Digest email:
<img width="1434" height="1318" alt="image" src="https://github.com/user-attachments/assets/6979c41d-c555-4cad-af87-4c3e05127a21" />
