### PR TITLE
Handle LaTeX encoded authors and abstracts

### DIFF
--- a/django_site/core/migrations/0013_decode_latex_author_names.py
+++ b/django_site/core/migrations/0013_decode_latex_author_names.py
@@ -34,7 +34,7 @@ def decode_latex_authors(apps, schema_editor):
 
     fixed = 0
     # iterator() keeps memory flat over a large papers table.
-    for paper in Paper.objects.iterator():
+    for paper in Paper.objects.only("id", "metadata").iterator():
         metadata = paper.metadata
         if not isinstance(metadata, dict):
             continue

--- a/django_site/core/migrations/0013_decode_latex_author_names.py
+++ b/django_site/core/migrations/0013_decode_latex_author_names.py
@@ -1,0 +1,76 @@
+r"""
+Decode LaTeX author names in papers.metadata to Unicode.
+
+arXiv's RSS feed encodes author names in LaTeX (e.g. ``J\'er\^ome`` for
+``Jérôme``). This migration converts existing RSS-ingested author names
+to Unicode, matching what the corrected pipeline now produces.
+
+Scope guards:
+  * Only RSS-ingested rows are touched (they carry ``announce_type`` in
+    metadata). API-path rows are already Unicode and are left alone.
+  * Only names containing a backslash are converted, so clean Unicode names
+    and apostrophes such as ``O'Brien`` are never altered.
+"""
+
+from django.db import migrations
+
+
+def _decode_name(text, converter):
+    """Convert a single LaTeX-encoded name to Unicode; leave clean names as-is."""
+    if not isinstance(text, str) or "\\" not in text:
+        return text
+    try:
+        return converter.latex_to_text(text).strip()
+    except Exception:
+        return text
+
+
+def decode_latex_authors(apps, schema_editor):
+    """Rewrite affected metadata["authors"] in place."""
+    from pylatexenc.latex2text import LatexNodes2Text
+
+    Paper = apps.get_model("core", "Paper")
+    converter = LatexNodes2Text()
+
+    fixed = 0
+    # iterator() keeps memory flat over a large papers table.
+    for paper in Paper.objects.iterator():
+        metadata = paper.metadata
+        if not isinstance(metadata, dict):
+            continue
+        # Only RSS-ingested rows carry announce_type (and LaTeX names).
+        if "announce_type" not in metadata:
+            continue
+        authors = metadata.get("authors")
+        if not isinstance(authors, list) or not authors:
+            continue
+
+        new_authors = [_decode_name(a, converter) for a in authors]
+        if new_authors == authors:
+            continue
+
+        metadata["authors"] = new_authors
+        paper.metadata = metadata
+        paper.save(update_fields=["metadata"])
+        fixed += 1
+
+    if fixed:
+        print(f"  Decoded LaTeX author names for {fixed} paper(s).")
+    else:
+        print("  No affected rows found.")
+
+
+def reverse_noop(apps, schema_editor):
+    """Unicode names are always preferable; no reason to revert."""
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0012_split_author_lists"),
+    ]
+
+    operations = [
+        migrations.RunPython(decode_latex_authors, reverse_noop),
+    ]

--- a/django_site/core/templates/base.html
+++ b/django_site/core/templates/base.html
@@ -25,7 +25,7 @@
       options: { skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'] }
     };
   </script>
-  <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" id="MathJax-script" async></script>
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-chtml.js" id="MathJax-script" async crossorigin="anonymous"></script>
 
   {% if ACCENT_COLOR or NAV_COLOR %}
   <style>

--- a/django_site/core/templates/base.html
+++ b/django_site/core/templates/base.html
@@ -12,6 +12,21 @@
 
   <link rel="stylesheet" href="{% static 'core/style.css' %}">
 
+  {# ── MathJax: render $…$ / $$…$$ math in titles, abstracts, and summaries ── #}
+  {# NOTE: only handles math-mode LaTeX. Text-mode author-name accents (\'e etc.) #}
+  {# are converted to Unicode server-side, not here. #}
+  <script>
+    window.MathJax = {
+      tex: {
+        inlineMath: [['$', '$'], ['\\(', '\\)']],
+        displayMath: [['$$', '$$'], ['\\[', '\\]']],
+        processEscapes: true
+      },
+      options: { skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'] }
+    };
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" id="MathJax-script" async></script>
+
   {% if ACCENT_COLOR or NAV_COLOR %}
   <style>
     :root {

--- a/django_site/core/templates/recommendations/list.html
+++ b/django_site/core/templates/recommendations/list.html
@@ -260,6 +260,11 @@ function applyFilters() {
 
   /* update URL */
   updateURL(f);
+
+  /* re-render any $…$ math in the freshly-built cards (titles, summaries, abstracts) */
+  if (window.MathJax && MathJax.typesetPromise) {
+    MathJax.typesetPromise([container]).catch(() => {});
+  }
 }
 
 /* ── Render grouped by date ───────────────────────── */

--- a/django_site/requirements.txt
+++ b/django_site/requirements.txt
@@ -12,3 +12,6 @@ arxiv>=2.1.0
 
 # PDF text layer validation on upload
 pypdf>=4.0.0
+
+# Decode LaTeX author names to Unicode (used by the 0013 backfill migration)
+pylatexenc>=2.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "requests>=2.31.0",
     "feedparser>=6.0.11",
     "lxml>=5.3.0",
+    "pylatexenc>=2.10",  # decode LaTeX author names from arXiv RSS to Unicode
 
     # progress bars
     "tqdm>=4.66.0",

--- a/src/preprint_bot/sources/arxiv.py
+++ b/src/preprint_bot/sources/arxiv.py
@@ -209,7 +209,8 @@ def _latex_to_unicode(text: str) -> str:
         return text
     try:
         return _LATEX2TEXT.latex_to_text(text).strip()
-    except Exception:
+    except Exception as e:
+        print(f"Could not convert assumed LaTeX {text} to unicode")
         return text
 
 

--- a/src/preprint_bot/sources/arxiv.py
+++ b/src/preprint_bot/sources/arxiv.py
@@ -15,12 +15,16 @@ from zoneinfo import ZoneInfo
 
 import feedparser
 import httpx
+from pylatexenc.latex2text import LatexNodes2Text
 
 from .base import PaperEntry, PreprintSource
 from ..config import USER_AGENT
 
 _RSS_BASE = "https://rss.arxiv.org/rss"
 _API_BASE = "https://export.arxiv.org/api/query"
+
+# Reused across calls; converts LaTeX text markup (e.g. ``\'e``) to Unicode.
+_LATEX2TEXT = LatexNodes2Text()
 
 
 class ArxivSource(PreprintSource):
@@ -194,11 +198,26 @@ def _clean_html(text: str) -> str:
     return text.strip()
 
 
+def _latex_to_unicode(text: str) -> str:
+    r"""Convert LaTeX text-mode markup to Unicode (``J\'er\^ome`` → ``Jérôme``).
+
+    arXiv encodes author names in LaTeX. Only strings containing a backslash
+    are processed, so already-clean Unicode names (and apostrophes such as
+    ``O'Brien``) are left untouched. Falls back to the input on error.
+    """
+    if "\\" not in text:
+        return text
+    try:
+        return _LATEX2TEXT.latex_to_text(text).strip()
+    except Exception:
+        return text
+
+
 def _parse_rss_authors(item) -> List[str]:
-    """Extract author list from an RSS item.
+    r"""Extract author list from an RSS item.
 
     arXiv's RSS puts all authors in a single ``<dc:creator>`` element
-    as one comma-separated string.
+    as one comma-separated string, LaTeX-encoded (e.g. ``J\'er\^ome``).
     """
     # Gather raw name strings from whichever field feedparser populated
     raw: List[str] = []
@@ -213,7 +232,8 @@ def _parse_rss_authors(item) -> List[str]:
     names: List[str] = []
     for entry in raw:
         names.extend(a.strip() for a in entry.split(",") if a.strip())
-    return names
+    # Decode LaTeX markup (accents etc.) to Unicode
+    return [_latex_to_unicode(n) for n in names]
 
 
 def _parse_rss_categories(item) -> List[str]:


### PR DESCRIPTION
This decodes authors from the arXiv RSS feed that are LaTeX-encoded. It also uses MathJax to handle LaTeX in abstracts/summaries across the website.

Fixes #94.