### PR TITLE
Show recent sent and failed emails on monitoring dashboard

### DIFF
--- a/django_site/core/templates/monitoring.html
+++ b/django_site/core/templates/monitoring.html
@@ -29,12 +29,17 @@
   table.mini th, table.mini td { text-align:left; padding:.3rem .4rem; border-bottom:1px solid #eee; }
   table.mini th { color:var(--text-dim); font-weight:600; }
   /* Email delivery: Sent/Failed toggle + scrollable lists */
-  .email-tabs > input[type=radio] { position:absolute; opacity:0; pointer-events:none; }
-  .email-tab-btns { display:inline-flex; border:1px solid #e5e7eb; border-radius:6px; overflow:hidden; margin:.6rem 0 .2rem; }
+  /* Radios are hidden off-screen but stay focusable; focus shows on the label. */
+  .email-tabs > input[type=radio] { position:absolute; width:1px; height:1px; opacity:0; }
+  .email-tab-btns { display:inline-flex; border:1px solid #e5e7eb; border-radius:6px; margin:.6rem 0 .2rem; }
   .email-tab-btns label { padding:.25rem .8rem; font-size:.8rem; cursor:pointer; color:var(--text-dim); user-select:none; }
+  .email-tab-btns label:first-of-type { border-radius:6px 0 0 6px; }
+  .email-tab-btns label:last-of-type { border-radius:0 6px 6px 0; }
   .email-tab-btns label + label { border-left:1px solid #e5e7eb; }
   #emailtab-sent:checked ~ .email-tab-btns label[for=emailtab-sent],
   #emailtab-failed:checked ~ .email-tab-btns label[for=emailtab-failed] { background:var(--accent,#F76900); color:#fff; }
+  #emailtab-sent:focus-visible ~ .email-tab-btns label[for=emailtab-sent],
+  #emailtab-failed:focus-visible ~ .email-tab-btns label[for=emailtab-failed] { outline:2px solid var(--accent,#F76900); outline-offset:2px; }
   .email-list { display:none; max-height:280px; overflow-y:auto; }
   #emailtab-sent:checked ~ .email-list--sent { display:block; }
   #emailtab-failed:checked ~ .email-list--failed { display:block; }

--- a/django_site/core/templates/monitoring.html
+++ b/django_site/core/templates/monitoring.html
@@ -28,6 +28,16 @@
   table.mini { width:100%; border-collapse:collapse; font-size:.82rem; margin-top:.3rem; }
   table.mini th, table.mini td { text-align:left; padding:.3rem .4rem; border-bottom:1px solid #eee; }
   table.mini th { color:var(--text-dim); font-weight:600; }
+  /* Email delivery: Sent/Failed toggle + scrollable lists */
+  .email-tabs > input[type=radio] { position:absolute; opacity:0; pointer-events:none; }
+  .email-tab-btns { display:inline-flex; border:1px solid #e5e7eb; border-radius:6px; overflow:hidden; margin:.6rem 0 .2rem; }
+  .email-tab-btns label { padding:.25rem .8rem; font-size:.8rem; cursor:pointer; color:var(--text-dim); user-select:none; }
+  .email-tab-btns label + label { border-left:1px solid #e5e7eb; }
+  #emailtab-sent:checked ~ .email-tab-btns label[for=emailtab-sent],
+  #emailtab-failed:checked ~ .email-tab-btns label[for=emailtab-failed] { background:var(--accent,#F76900); color:#fff; }
+  .email-list { display:none; max-height:280px; overflow-y:auto; }
+  #emailtab-sent:checked ~ .email-list--sent { display:block; }
+  #emailtab-failed:checked ~ .email-list--failed { display:block; }
 </style>
 {% endblock %}
 
@@ -89,20 +99,50 @@
       <div class="kpi-label">Failure rate</div>
     </div>
   </div>
-  {% if recent_email_failures %}
-  <table class="mini">
-    <thead><tr><th>When</th><th>User</th><th>Subject</th></tr></thead>
-    <tbody>
-      {% for e in recent_email_failures %}
-      <tr>
-        <td>{{ e.sent_at|date:"M j, H:i" }}</td>
-        <td>{{ e.user.email }}</td>
-        <td>{{ e.subject|default:"—"|truncatechars:60 }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  {% endif %}
+  <div class="email-tabs">
+    <input type="radio" name="emailtab" id="emailtab-sent" checked>
+    <input type="radio" name="emailtab" id="emailtab-failed">
+    <div class="email-tab-btns">
+      <label for="emailtab-sent">Sent</label>
+      <label for="emailtab-failed">Failed</label>
+    </div>
+    <div class="email-list email-list--sent">
+      {% if recent_sent %}
+      <table class="mini">
+        <thead><tr><th>When</th><th>User</th><th>Subject</th></tr></thead>
+        <tbody>
+          {% for e in recent_sent %}
+          <tr>
+            <td>{{ e.sent_at|date:"M j, H:i" }}</td>
+            <td>{{ e.user.email }}</td>
+            <td>{{ e.subject|default:"—"|truncatechars:60 }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p class="text-sm text-dim">No sent emails in the last {{ window_days }} days.</p>
+      {% endif %}
+    </div>
+    <div class="email-list email-list--failed">
+      {% if recent_failed %}
+      <table class="mini">
+        <thead><tr><th>When</th><th>User</th><th>Subject</th></tr></thead>
+        <tbody>
+          {% for e in recent_failed %}
+          <tr>
+            <td>{{ e.sent_at|date:"M j, H:i" }}</td>
+            <td>{{ e.user.email }}</td>
+            <td>{{ e.subject|default:"—"|truncatechars:60 }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p class="text-sm text-dim">No failed emails in the last {{ window_days }} days.</p>
+      {% endif %}
+    </div>
+  </div>
 </div>
 
 {# ── Ingestion ── #}

--- a/django_site/core/views.py
+++ b/django_site/core/views.py
@@ -1547,11 +1547,9 @@ def monitoring_dashboard_view(request):
     email_failed = email_counts["failed"] or 0
     email_total = email_sent + email_failed
     email_failure_rate = (email_failed / email_total * 100) if email_total else 0
-    recent_email_failures = list(
-        EmailLog.objects.filter(status="failed")
-        .select_related("user")
-        .order_by("-sent_at")[:10]
-    )
+    _recent_emails = EmailLog.objects.filter(sent_at__gte=since).select_related("user")
+    recent_sent = list(_recent_emails.filter(status="sent").order_by("-sent_at")[:100])
+    recent_failed = list(_recent_emails.filter(status="failed").order_by("-sent_at")[:100])
 
     # ── Ingestion (real; ArxivDailyStats is empty, so derive from Paper) ──
     total_papers = Paper.objects.count()
@@ -1603,7 +1601,8 @@ def monitoring_dashboard_view(request):
         "email_sent": email_sent,
         "email_failed": email_failed,
         "email_failure_rate": round(email_failure_rate, 1),
-        "recent_email_failures": recent_email_failures,
+        "recent_sent": recent_sent,
+        "recent_failed": recent_failed,
         # ingestion
         "total_papers": total_papers,
         "papers_by_source": papers_by_source,


### PR DESCRIPTION
**Before**: monitoring dashboard only listed failed emails (with no time/number limit)
**After**: monitoring dashboard lists the 100 most recent sent emails and 100 most recent failed emails (split out by send status)

<img width="1348" height="571" alt="image" src="https://github.com/user-attachments/assets/c5e767e4-a005-4afc-970d-b48058fe22ea" />

Fixes https://github.com/SU-OSPO/preprint-bot/issues/108.