### PR TITLE
Improve embeddings retrieval performance

### DIFF
--- a/routes/embeddings.py
+++ b/routes/embeddings.py
@@ -87,7 +87,8 @@ async def batch_create_embeddings(embeddings: List[EmbeddingCreate]):
 async def get_embeddings(
     paper_id: Optional[int] = Query(None),
     corpus_id: Optional[int] = Query(None),
-    type: Optional[str] = Query(None)
+    type: Optional[str] = Query(None),
+    paper_ids: Optional[List[int]] = Query(None)
 ):
     """Get embeddings with optional filters"""
     pool = await get_db_pool()
@@ -109,6 +110,11 @@ async def get_embeddings(
     if type is not None:
         conditions.append(f"e.type = ${idx}")
         params.append(type)
+        idx += 1
+    
+    if paper_ids:
+        conditions.append(f"e.paper_id = ANY(${idx})")
+        params.append(paper_ids)
         idx += 1
     
     where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""

--- a/routes/embeddings.py
+++ b/routes/embeddings.py
@@ -91,6 +91,11 @@ async def get_embeddings(
     paper_ids: Optional[List[int]] = Query(None)
 ):
     """Get embeddings with optional filters"""
+    if paper_id is not None and paper_ids is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="Specify either paper_id or paper_ids, not both.",
+        )
     pool = await get_db_pool()
     
     conditions = []
@@ -112,7 +117,7 @@ async def get_embeddings(
         params.append(type)
         idx += 1
     
-    if paper_ids:
+    if paper_ids is not None:
         conditions.append(f"e.paper_id = ANY(${idx})")
         params.append(paper_ids)
         idx += 1

--- a/src/preprint_bot/api_client.py
+++ b/src/preprint_bot/api_client.py
@@ -3,6 +3,11 @@ from typing import List, Dict, Optional
 import datetime
 import asyncio
 
+# Chunk size for GET /embeddings/?paper_ids=... so the request URL stays well
+# under the server's header-size limit when filtering to many papers.
+_EMBED_ID_CHUNK = 200
+
+
 class APIClient:
     def __init__(self, base_url: str = "http://127.0.0.1:8000"):
         self.base_url = base_url
@@ -225,11 +230,27 @@ class APIClient:
         response.raise_for_status()
         return response.json()
     
-    async def get_embeddings_by_corpus(self, corpus_id: int, type: str = None) -> List[Dict]:
+    async def get_embeddings_by_corpus(
+        self, corpus_id: int, type: str = None,
+        paper_ids: Optional[List[int]] = None,
+    ) -> List[Dict]:
         params = {"corpus_id": corpus_id}
         if type:
             params["type"] = type
-        return await self._get_embeddings_retry(params)
+
+        # No id filter: one request for the whole corpus.
+        if not paper_ids:
+            return await self._get_embeddings_retry(params)
+
+        # Filter to specific papers in SQL, chunking the id list so the request
+        # URL stays under the server's header-size limit.
+        results: List[Dict] = []
+        for i in range(0, len(paper_ids), _EMBED_ID_CHUNK):
+            chunk = paper_ids[i:i + _EMBED_ID_CHUNK]
+            results.extend(
+                await self._get_embeddings_retry({**params, "paper_ids": chunk})
+            )
+        return results
 
     async def _get_embeddings_retry(
         self, params: Dict, max_retries: int = 4, backoff: float = 2.0,

--- a/src/preprint_bot/api_client.py
+++ b/src/preprint_bot/api_client.py
@@ -1,6 +1,7 @@
 import httpx
 from typing import List, Dict, Optional
 import datetime
+import asyncio
 
 class APIClient:
     def __init__(self, base_url: str = "http://127.0.0.1:8000"):
@@ -228,12 +229,28 @@ class APIClient:
         params = {"corpus_id": corpus_id}
         if type:
             params["type"] = type
-        response = await self.client.get(
-            f"{self.base_url}/embeddings/",
-            params=params
-        )
-        response.raise_for_status()
-        return response.json()
+        return await self._get_embeddings_retry(params)
+
+    async def _get_embeddings_retry(
+        self, params: Dict, max_retries: int = 4, backoff: float = 2.0,
+    ) -> List[Dict]:
+        """GET /embeddings/ with retry + backoff on dropped connections."""
+        timeout = httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0)
+        last_exc = None
+        for attempt in range(1, max_retries + 1):
+            try:
+                async with httpx.AsyncClient(timeout=timeout) as client:
+                    response = await client.get(f"{self.base_url}/embeddings/", params=params)
+                    response.raise_for_status()
+                    return response.json()
+            except httpx.TransportError as e:
+                last_exc = e
+                if attempt < max_retries:
+                    wait = backoff * (2 ** (attempt - 1))
+                    print(f"  embeddings fetch attempt {attempt}/{max_retries} failed "
+                          f"({e.__class__.__name__}); retrying in {wait:.0f}s")
+                    await asyncio.sleep(wait)
+        raise last_exc
     
     async def get_embeddings_by_paper(self, paper_id: int, type: str = None) -> List[Dict]:
         params = {"paper_id": paper_id}

--- a/src/preprint_bot/api_client.py
+++ b/src/preprint_bot/api_client.py
@@ -4,7 +4,7 @@ import datetime
 import asyncio
 
 # Chunk size for GET /embeddings/?paper_ids=... so the request URL stays well
-# under the server's header-size limit when filtering to many papers.
+# under the server's request-line length limit when filtering to many papers.
 _EMBED_ID_CHUNK = 200
 
 
@@ -238,32 +238,36 @@ class APIClient:
         if type:
             params["type"] = type
 
-        # No id filter: one request for the whole corpus.
-        if not paper_ids:
-            return await self._get_embeddings_retry(params)
+        # Keep-alives disabled so every request (and retry) opens a fresh connection
+        timeout = httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0)
+        limits = httpx.Limits(max_keepalive_connections=0)
+        async with httpx.AsyncClient(timeout=timeout, limits=limits) as client:
+            # No id filter provided: one request for the whole corpus. An
+            # explicitly-empty list falls through and yields no results.
+            if paper_ids is None:
+                return await self._get_embeddings_retry(client, params)
 
-        # Filter to specific papers in SQL, chunking the id list so the request
-        # URL stays under the server's header-size limit.
-        results: List[Dict] = []
-        for i in range(0, len(paper_ids), _EMBED_ID_CHUNK):
-            chunk = paper_ids[i:i + _EMBED_ID_CHUNK]
-            results.extend(
-                await self._get_embeddings_retry({**params, "paper_ids": chunk})
-            )
-        return results
+            # Filter to specific papers in SQL, chunking the id list so the
+            # request URL stays under the server's request-line length limit.
+            results: List[Dict] = []
+            for i in range(0, len(paper_ids), _EMBED_ID_CHUNK):
+                chunk = paper_ids[i:i + _EMBED_ID_CHUNK]
+                results.extend(
+                    await self._get_embeddings_retry(client, {**params, "paper_ids": chunk})
+                )
+            return results
 
     async def _get_embeddings_retry(
-        self, params: Dict, max_retries: int = 4, backoff: float = 2.0,
+        self, client: httpx.AsyncClient, params: Dict,
+        max_retries: int = 4, backoff: float = 2.0,
     ) -> List[Dict]:
         """GET /embeddings/ with retry + backoff on dropped connections."""
-        timeout = httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0)
         last_exc = None
         for attempt in range(1, max_retries + 1):
             try:
-                async with httpx.AsyncClient(timeout=timeout) as client:
-                    response = await client.get(f"{self.base_url}/embeddings/", params=params)
-                    response.raise_for_status()
-                    return response.json()
+                response = await client.get(f"{self.base_url}/embeddings/", params=params)
+                response.raise_for_status()
+                return response.json()
             except httpx.TransportError as e:
                 last_exc = e
                 if attempt < max_retries:

--- a/src/preprint_bot/db_similarity_matcher.py
+++ b/src/preprint_bot/db_similarity_matcher.py
@@ -102,20 +102,18 @@ async def run_similarity_matching(
     print(f"\nCreated recommendation run ID: {run_id}")
     
     # Fetch embeddings based on mode
-    if use_sections:
-        print("\nFetching embeddings (abstract + sections)...")
-        user_embeddings = await api_client.get_embeddings_by_corpus(user_corpus_id)
-        all_arxiv_embeddings = await api_client.get_embeddings_by_corpus(arxiv_corpus_id)
-    else:
-        print("\nFetching embeddings (abstract only)...")
-        user_embeddings = await api_client.get_embeddings_by_corpus(user_corpus_id, type="abstract")
-        all_arxiv_embeddings = await api_client.get_embeddings_by_corpus(arxiv_corpus_id, type="abstract")
-
-    # Keep only embeddings for candidate papers
+    # Fetch embeddings for user's papers
+    emb_type = None if use_sections else "abstract"
+    print(f"\nFetching embeddings ({'abstract + sections' if use_sections else 'abstract only'})...")
+    user_embeddings = await api_client.get_embeddings_by_corpus(user_corpus_id, type=emb_type)
+    
+    # Fetch embeddings for new arXiv papers
     if candidate_ids:
-        arxiv_embeddings = [e for e in all_arxiv_embeddings if e['paper_id'] in candidate_ids]
+        arxiv_embeddings = await api_client.get_embeddings_by_corpus(
+            arxiv_corpus_id, type=emb_type, paper_ids=list(candidate_ids)
+        )
     else:
-        arxiv_embeddings = all_arxiv_embeddings
+        arxiv_embeddings = await api_client.get_embeddings_by_corpus(arxiv_corpus_id, type=emb_type)
     
     if not user_embeddings:
         print("Error: No user embeddings found. Run embedding step first.")


### PR DESCRIPTION
This makes the following performance improvements for how embeddings are retrieved as part of the nightly pipeline:

1. Embeddings retrieval from the database is now retried if it fails (e.g., if the API stalls out mid-retrieval) (Fixes #102)
2. arXiv embeddings retrieval is now filtered to only new papers at the API/database-level, reducing the overhead of the retrieval and reducing the amount of processing required in the pipeline (Fixes #103)