### PR TITLE
Send email to admin when pipeline fails

### DIFF
--- a/dummy_config.py
+++ b/dummy_config.py
@@ -97,6 +97,7 @@ EMAIL_USER = ""  # TODO: SMTP login username
 EMAIL_PASSWORD = ""  # TODO: SMTP login password
 EMAIL_FROM_ADDRESS = "noreply@localhost"  # TODO: sender address
 EMAIL_FROM_NAME = "Preprint Bot"  # TODO: sender display name
+ADMIN_EMAIL = ""  # TODO: address to alert when the pipeline errors (defaults to EMAIL_FROM_ADDRESS if empty)
 
 # ==================== DATABASE SETTINGS ====================
 

--- a/routes/emails.py
+++ b/routes/emails.py
@@ -5,7 +5,7 @@ from typing import Optional
 from datetime import date, datetime
 import json
 from database import get_db_pool
-from services.email_service import send_recommendations_digest, send_email
+from services.email_service import send_recommendations_digest, send_email, send_admin_alert
 
 router = APIRouter(prefix="/emails", tags=["emails"])
 
@@ -121,3 +121,15 @@ async def test_email(to_email: str):
     if not success:
         raise HTTPException(status_code=500, detail="Test email failed")
     return {"status": "sent", "to": to_email}
+
+
+class AdminAlertRequest(BaseModel):
+    subject: str
+    detail: str
+
+
+@router.post("/admin-alert")
+async def admin_alert(req: AdminAlertRequest):
+    """Email the configured admin address about a pipeline failure."""
+    sent = await run_in_threadpool(send_admin_alert, req.subject, req.detail)
+    return {"sent": sent}

--- a/routes/emails.py
+++ b/routes/emails.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException
 from fastapi.concurrency import run_in_threadpool
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Optional
 from datetime import date, datetime
 import json
@@ -124,8 +124,8 @@ async def test_email(to_email: str):
 
 
 class AdminAlertRequest(BaseModel):
-    subject: str
-    detail: str
+    subject: str = Field(max_length=300)
+    detail: str = Field(max_length=20000)
 
 
 @router.post("/admin-alert")

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -118,6 +118,8 @@ def send_admin_alert(subject: str, detail: str) -> bool:
     if not recipient:
         print("Admin alert skipped: no ADMIN_EMAIL or EMAIL_FROM_ADDRESS set.")
         return False
+    # Strip CR/LF to prevent header injection, and bound the subject length.
+    subject = subject.replace("\r", " ").replace("\n", " ")[:300]
     html_body = (
         "<p>The Preprint Bot pipeline reported an error:</p>"
         "<pre style=\"white-space:pre-wrap;font-size:13px;background:#f6f6f6;"

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -9,6 +9,10 @@ from typing import List, Dict
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from config import EMAIL_HOST, EMAIL_PORT, EMAIL_USER, EMAIL_PASSWORD, EMAIL_FROM_ADDRESS, EMAIL_FROM_NAME, SITE_URL
+try:
+    from config import ADMIN_EMAIL
+except ImportError:
+    ADMIN_EMAIL = ""
 
 DASHBOARD_URL = SITE_URL
 SU_ORANGE = "#F76900"
@@ -105,6 +109,22 @@ def send_email(to_address: str, subject: str, html_body: str) -> bool:
     except Exception as e:
         print(f"Email send failed: {e}")
         return False
+
+
+def send_admin_alert(subject: str, detail: str) -> bool:
+    """Email the admin about a pipeline failure."""
+    # Fall back to EMAIL_FROM_ADDRESS when ADMIN_EMAIL is not configured
+    recipient = ADMIN_EMAIL or EMAIL_FROM_ADDRESS
+    if not recipient:
+        print("Admin alert skipped: no ADMIN_EMAIL or EMAIL_FROM_ADDRESS set.")
+        return False
+    html_body = (
+        "<p>The Preprint Bot pipeline reported an error:</p>"
+        "<pre style=\"white-space:pre-wrap;font-size:13px;background:#f6f6f6;"
+        "padding:12px;border-radius:6px;overflow-x:auto;\">"
+        f"{html.escape(detail)}</pre>"
+    )
+    return send_email(recipient, subject, html_body)
 
 
 def send_recommendations_digest(

--- a/src/preprint_bot/api_client.py
+++ b/src/preprint_bot/api_client.py
@@ -360,3 +360,12 @@ class APIClient:
         response = await self.client.get(f"{self.base_url}/papers/arxiv-stats/date/{date}")
         response.raise_for_status()
         return response.json()
+
+    async def send_admin_alert(self, subject: str, detail: str) -> Dict:
+        """Ask the API to email the configured admin about a pipeline failure."""
+        response = await self.client.post(
+            f"{self.base_url}/emails/admin-alert",
+            json={"subject": subject, "detail": detail},
+        )
+        response.raise_for_status()
+        return response.json()

--- a/src/preprint_bot/pipeline.py
+++ b/src/preprint_bot/pipeline.py
@@ -615,17 +615,23 @@ async def run_pipeline(args):
 
 
 def _notify_admin_of_failure(detail: str):
-    """Ask the API to email the admin about a pipeline failure."""
+    """Ask the API to email the admin about a pipeline failure (best-effort)."""
+    # Keep the tail of long tracebacks — the exception and innermost frames.
+    max_detail = 8000
+    if len(detail) > max_detail:
+        detail = "…(truncated)…\n" + detail[-max_detail:]
+
     async def _send():
         client = APIClient(base_url=API_BASE_URL)
         try:
-            subject = f"\u26a0\ufe0f Preprint Bot pipeline failed \u2014 {datetime.now():%Y-%m-%d %H:%M}"
+            subject = f"\u26a0\ufe0f Preprint Bot pipeline failed \u2014 {datetime.now(timezone.utc):%Y-%m-%d %H:%M %Z}"
             return await client.send_admin_alert(subject, detail)
         finally:
             await client.close()
 
     try:
-        resp = asyncio.run(_send())
+        # Bounded so a down or slow API can't hold the pipeline process open.
+        resp = asyncio.run(asyncio.wait_for(_send(), timeout=20))
         if resp.get("sent"):
             print("  Sent pipeline-failure alert to admin.")
         else:

--- a/src/preprint_bot/pipeline.py
+++ b/src/preprint_bot/pipeline.py
@@ -5,6 +5,7 @@ Database-integrated Preprint Recommender Pipeline
 import argparse
 import asyncio
 import sys
+import traceback
 from pathlib import Path
 from typing import List
 from datetime import datetime, timezone, date as date_type
@@ -613,6 +614,26 @@ async def run_pipeline(args):
         await api_client.close()
 
 
+def _notify_admin_of_failure(detail: str):
+    """Ask the API to email the admin about a pipeline failure."""
+    async def _send():
+        client = APIClient(base_url=API_BASE_URL)
+        try:
+            subject = f"\u26a0\ufe0f Preprint Bot pipeline failed \u2014 {datetime.now():%Y-%m-%d %H:%M}"
+            return await client.send_admin_alert(subject, detail)
+        finally:
+            await client.close()
+
+    try:
+        resp = asyncio.run(_send())
+        if resp.get("sent"):
+            print("  Sent pipeline-failure alert to admin.")
+        else:
+            print("  Admin alert not sent (email delivery failed).")
+    except Exception as e:
+        print(f"  Warning: could not send admin failure alert: {e}")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Preprint Bot Pipeline")
     mode = parser.add_mutually_exclusive_group()
@@ -628,7 +649,18 @@ def main():
     parser.add_argument("--llm-model", default="models/llama-3.2-3b-instruct-q4_k_m.gguf", help="Path to LLM model")
 
     args = parser.parse_args()
-    asyncio.run(run_pipeline(args))
+    try:
+        asyncio.run(run_pipeline(args))
+    except SystemExit as e:
+        # Preflight/validation aborts (e.g. no categories, unreachable services).
+        if e.code not in (0, None):
+            _notify_admin_of_failure(
+                f"Pipeline aborted early (exit code {e.code}). See pipeline logs for details."
+            )
+        raise
+    except Exception:
+        _notify_admin_of_failure(traceback.format_exc())
+        raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This prompts the API to send an email to the admin/from email when the pipeline doesn't complete successfully. Note that if the API is down, the email sending will also fail.

Fixes #90.