### PR TITLE
Helper package for preprint source abstraction

### DIFF
--- a/.github/workflows/preprint-sources.yml
+++ b/.github/workflows/preprint-sources.yml
@@ -1,0 +1,45 @@
+name: preprint_sources tests
+
+# Independent, light package — only runs when it (or this workflow) changes.
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'packages/preprint_sources/**'
+      - '.github/workflows/preprint-sources.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'packages/preprint_sources/**'
+      - '.github/workflows/preprint-sources.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ '3.10', '3.11', '3.12' ]
+
+    defaults:
+      run:
+        working-directory: packages/preprint_sources
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install the package with test extras
+        run: |
+          python -m pip install --upgrade pip
+          # Deps come from pyproject.toml — light: httpx / feedparser / pylatexenc.
+          pip install -e ".[test]"
+
+      - name: Run tests
+        run: pytest -v --tb=short

--- a/packages/preprint_sources/README.md
+++ b/packages/preprint_sources/README.md
@@ -1,0 +1,53 @@
+# preprint-sources
+
+Light, shared package of **preprint-server source adapters** for Preprint Bot.
+
+Each supported server implements the `PreprintSource` interface: fetching new
+papers, its category taxonomy, and source-aware landing/PDF URLs. The package
+is deliberately dependency-lean so that **both** the heavy pipeline package
+(`preprint_bot`) and the lean Django web app can depend on it without either
+pulling in the other's dependencies.
+
+## Layout
+
+```
+src/preprint_sources/
+  base.py            # PaperEntry, PreprintSource (the interface)
+  arxiv.py           # ArxivSource
+  taxonomies/        # per-source category trees (e.g. arxiv.py)
+  registry.py        # name -> class, enabled_sources()
+  settings.py        # USER_AGENT (env-overridable)
+```
+
+## Usage
+
+```python
+from preprint_sources import get_source, enabled_sources, all_source_names
+
+src = get_source("arxiv")
+src.name            # "arxiv"
+src.label           # "arXiv"
+src.landing_url("2401.12345")   # https://arxiv.org/abs/2401.12345
+src.category_tree()             # nested tree for the picker UI
+papers = await src.fetch_latest(["cs.AI", "cs.LG"])
+
+# Which sources are on:
+#   PREPRINT_ENABLED_SOURCES="arxiv,biorxiv"
+for source in enabled_sources():
+    ...
+```
+
+## Adding a source
+
+1. Implement `PreprintSource` in a new module (e.g., `biorxiv.py`).
+2. Register it in `registry.py` `_CLASSES`.
+3. Add its name to `PREPRINT_ENABLED_SOURCES`.
+
+## Development
+
+From `packages/preprint_sources/`:
+
+```bash
+pip install -e ".[test]"
+pytest
+```

--- a/packages/preprint_sources/pyproject.toml
+++ b/packages/preprint_sources/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Preprint-server source adapters (fetch, taxonomy, URLs) shared by the pipeline and the web app."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = { text = "GPL-3.0-or-later" }
 authors = [
     { name = "Syracuse University Open Source Program Office", email = "ospo@syr.edu" },
 ]

--- a/packages/preprint_sources/pyproject.toml
+++ b/packages/preprint_sources/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "preprint-sources"
+dynamic = ["version"]
+description = "Preprint-server source adapters (fetch, taxonomy, URLs) shared by the pipeline and the web app."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "Syracuse University Open Source Program Office", email = "ospo@syr.edu" },
+]
+dependencies = [
+    "httpx>=0.27.0",
+    "feedparser>=6.0.11",
+    "pylatexenc>=2.10",  # decode LaTeX author names from arXiv RSS to Unicode
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[tool.setuptools.dynamic]
+version = {attr = "preprint_sources.__version__"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+asyncio_mode = "auto"

--- a/packages/preprint_sources/src/preprint_sources/__init__.py
+++ b/packages/preprint_sources/src/preprint_sources/__init__.py
@@ -1,0 +1,25 @@
+"""preprint_sources: fetch, taxonomy, and URLs for preprint servers.
+
+A light, dependency-lean package (httpx / feedparser / pylatexenc) shared by
+the pipeline and the web app so neither hardcodes server-specific details.
+"""
+from .arxiv import ArxivSource
+from .base import PaperEntry, PreprintSource
+from .registry import (
+    all_source_names,
+    enabled_names,
+    enabled_sources,
+    get_source,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "PaperEntry",
+    "PreprintSource",
+    "ArxivSource",
+    "all_source_names",
+    "get_source",
+    "enabled_names",
+    "enabled_sources",
+]

--- a/packages/preprint_sources/src/preprint_sources/arxiv.py
+++ b/packages/preprint_sources/src/preprint_sources/arxiv.py
@@ -1,0 +1,408 @@
+"""
+arXiv preprint source.
+
+Primary method: RSS feed (contains exactly the latest announcement).
+Fallback: arXiv search API with submission-window calculation (for
+backfilling historical dates).
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import datetime, timedelta, timezone
+from typing import List
+from zoneinfo import ZoneInfo
+
+import feedparser
+import httpx
+from pylatexenc.latex2text import LatexNodes2Text
+
+from .base import PaperEntry, PreprintSource
+from .settings import USER_AGENT
+from .taxonomies.arxiv import (
+    ARXIV_CATEGORY_TREE,
+    ARXIV_LEAF_CODES,
+    label_for as _arxiv_label_for,
+)
+
+_RSS_BASE = "https://rss.arxiv.org/rss"
+_API_BASE = "https://export.arxiv.org/api/query"
+
+# Reused across calls; converts LaTeX text markup (e.g. ``\'e``) to Unicode.
+_LATEX2TEXT = LatexNodes2Text()
+
+
+class ArxivSource(PreprintSource):
+    """Fetch new papers from arXiv via RSS or the search API."""
+
+    @property
+    def name(self) -> str:
+        return "arxiv"
+
+    @property
+    def label(self) -> str:
+        return "arXiv"
+
+    def landing_url(self, source_id: str) -> str:
+        return f"https://arxiv.org/abs/{source_id}"
+
+    def category_tree(self) -> list:
+        return ARXIV_CATEGORY_TREE
+
+    def leaf_codes(self) -> set:
+        return ARXIV_LEAF_CODES
+
+    def label_for(self, code: str) -> str:
+        return _arxiv_label_for(code)
+
+    # ── RSS (primary) ──────────────────────────────────────────────
+
+    async def fetch_latest(
+        self, categories: List[str]
+    ) -> List[PaperEntry]:
+        """Fetch the current announcement via the arXiv RSS feed.
+
+        The RSS feed is updated daily at midnight EST and contains
+        exactly the papers from the most recent announcement.  We
+        filter for ``announce_type == 'new'`` to skip replacements
+        and cross-listings.
+        """
+        # Combine categories with '+' to fetch a single merged feed
+        cat_str = "+".join(categories)
+        url = f"{_RSS_BASE}/{cat_str}"
+
+        print(f"\nFetching latest arXiv papers via RSS")
+        print(f"  Feed: {url}")
+        print(f"  Categories: {categories}")
+
+        async with httpx.AsyncClient(
+            timeout=30, headers={"User-Agent": USER_AGENT}
+        ) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+
+        feed = feedparser.parse(resp.text)
+
+        entries: List[PaperEntry] = []
+        seen_ids: set[str] = set()
+
+        for item in feed.entries:
+            # Only new submissions (skip replace, cross, replace-cross)
+            announce_type = getattr(item, "arxiv_announce_type", "new")
+            if announce_type != "new":
+                continue
+
+            arxiv_id = _extract_arxiv_id(item.link)
+            if not arxiv_id or arxiv_id in seen_ids:
+                continue
+            seen_ids.add(arxiv_id)
+
+            entries.append(
+                PaperEntry(
+                    source_id=arxiv_id,
+                    title=_clean_rss_title(item.title),
+                    abstract=_clean_html(
+                        getattr(item, "description", "")
+                        or getattr(item, "summary", "")
+                    ),
+                    url=item.link,
+                    pdf_url=f"https://arxiv.org/pdf/{arxiv_id}.pdf",
+                    authors=_parse_rss_authors(item),
+                    categories=_parse_rss_categories(item),
+                    published=getattr(item, "published", ""),
+                    source="arxiv",
+                    metadata={
+                        "arxiv_url": item.link,
+                        "announce_type": announce_type,
+                    },
+                )
+            )
+
+        print(f"  Found {len(entries)} new papers")
+        return entries
+
+    # ── API with submission windows (backfill) ─────────────────────
+
+    async def fetch_by_date(
+        self,
+        target_date,
+        categories: List[str],
+    ) -> List[PaperEntry]:
+        """Fetch papers for a specific date using the arXiv search API.
+
+        Uses ``_get_announcement_window`` to map the target date to the
+        correct submission window, then queries ``submittedDate``.
+        """
+        window = _get_announcement_window(target_date)
+        if window is None:
+            print(
+                f"\nNo arXiv announcement on "
+                f"{target_date.strftime('%A %Y-%m-%d')} — skipping fetch."
+            )
+            return []
+
+        start_dt, end_dt = window
+        start = start_dt.strftime("%Y%m%d%H%M")
+        end = end_dt.strftime("%Y%m%d%H%M")
+
+        print(
+            f"\nFetching arXiv papers via API for "
+            f"{target_date.strftime('%A %Y-%m-%d')}"
+        )
+        print(f"  Submission window: {start_dt} → {end_dt} (UTC)")
+        print(f"  Categories: {categories}")
+
+        entries: List[PaperEntry] = []
+        seen_ids: set[str] = set()
+
+        async with httpx.AsyncClient(
+            timeout=30, headers={"User-Agent": USER_AGENT}
+        ) as client:
+            # Combine all categories into a single OR query to avoid
+            # per-category rate limiting (26 categories = 26 requests)
+            cat_query = "+OR+".join(f"cat:{cat}" for cat in categories)
+            query = f"({cat_query})+AND+submittedDate:[{start}+TO+{end}]"
+
+            papers = await _api_fetch_all(client, query)
+            for item in papers:
+                arxiv_id = item.id.split("/")[-1]
+                if arxiv_id in seen_ids:
+                    continue
+                seen_ids.add(arxiv_id)
+
+                entries.append(
+                    PaperEntry(
+                        source_id=arxiv_id,
+                        title=item.title.strip(),
+                        abstract=item.summary.strip(),
+                        url=item.id,
+                        pdf_url=f"https://arxiv.org/pdf/{arxiv_id}.pdf",
+                        authors=[
+                            a.name
+                            for a in getattr(item, "authors", [])
+                        ],
+                        categories=[
+                            tag.term
+                            for tag in getattr(item, "tags", [])
+                        ],
+                        published=getattr(item, "published", ""),
+                        source="arxiv",
+                        metadata={"arxiv_url": item.id},
+                    )
+                )
+
+        print(f"  Total: {len(entries)} new papers")
+        return entries
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+
+def _extract_arxiv_id(link: str) -> str | None:
+    """Pull the arXiv ID from an abstract URL, stripping any version."""
+    m = re.search(r"abs/([^\s?#]+)", link or "")
+    if not m:
+        return None
+    raw = m.group(1)
+    return re.sub(r"v\d+$", "", raw)  # strip version suffix
+
+
+def _clean_rss_title(raw: str) -> str:
+    """Remove the 'arXiv:2401.12345' prefix that the RSS feed prepends."""
+    return re.sub(r"^arXiv:\S+\s*", "", raw).strip()
+
+
+def _clean_html(text: str) -> str:
+    """Strip HTML tags from RSS description fields."""
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def _latex_to_unicode(text: str) -> str:
+    r"""Convert LaTeX text-mode markup to Unicode (``J\'er\^ome`` → ``Jérôme``).
+
+    arXiv encodes author names in LaTeX. Only strings containing a backslash
+    are processed, so already-clean Unicode names (and apostrophes such as
+    ``O'Brien``) are left untouched. Falls back to the input on error.
+    """
+    if "\\" not in text:
+        return text
+    try:
+        return _LATEX2TEXT.latex_to_text(text).strip()
+    except Exception as e:
+        print(f"Could not convert assumed LaTeX {text} to unicode")
+        return text
+
+
+def _parse_rss_authors(item) -> List[str]:
+    r"""Extract author list from an RSS item.
+
+    arXiv's RSS puts all authors in a single ``<dc:creator>`` element
+    as one comma-separated string, LaTeX-encoded (e.g. ``J\'er\^ome``).
+    """
+    # Gather raw name strings from whichever field feedparser populated
+    raw: List[str] = []
+    if hasattr(item, "authors") and item.authors:
+        raw = [a.get("name", "") for a in item.authors if a.get("name")]
+    if not raw:
+        author_str = getattr(item, "author", "")
+        if author_str:
+            raw = [author_str]
+
+    # Split any comma-joined entries into individual authors
+    names: List[str] = []
+    for entry in raw:
+        names.extend(a.strip() for a in entry.split(",") if a.strip())
+    # Decode LaTeX markup (accents etc.) to Unicode
+    return [_latex_to_unicode(n) for n in names]
+
+
+def _parse_rss_categories(item) -> List[str]:
+    """Extract category list from an RSS item."""
+    if hasattr(item, "tags") and item.tags:
+        return [tag.term for tag in item.tags if hasattr(tag, "term")]
+    return []
+
+
+async def _api_fetch_all(
+    client: httpx.AsyncClient,
+    query: str,
+    page_size: int = 500,
+) -> list:
+    """Fetch all results for a query, paginating as needed.
+
+    The arXiv API caps ``max_results`` at ~30 000, but practical
+    pages should be ≤ 500 to avoid timeouts.  We read
+    ``opensearch:totalResults`` from the first page to know how
+    many pages to fetch.
+    """
+    all_entries: list = []
+    offset = 0
+    total: int | None = None  # learned from first response
+
+    while True:
+        url = (
+            f"{_API_BASE}?search_query={query}"
+            f"&start={offset}&max_results={page_size}"
+            f"&sortBy=submittedDate&sortOrder=descending"
+        )
+        result = await _api_fetch_page(client, url)
+
+        if result is None:
+            break  # retries exhausted
+
+        feed_entries, feed_total = result
+        all_entries.extend(feed_entries)
+
+        # Learn total from first response
+        if total is None:
+            total = feed_total
+            if total is not None and total > page_size:
+                print(f"  {total} total results, paginating...")
+
+        # Stop if we got fewer than a full page or we've fetched everything
+        if len(feed_entries) < page_size:
+            break
+        if total is not None and len(all_entries) >= total:
+            break
+
+        offset += page_size
+        await asyncio.sleep(5)  # polite delay between pages
+
+    print(f"  Fetched {len(all_entries)} papers via API")
+    return all_entries
+
+
+async def _api_fetch_page(
+    client: httpx.AsyncClient,
+    url: str,
+    max_retries: int = 4,
+    backoff: int = 10,
+) -> tuple[list, int | None] | None:
+    """Fetch a single page from the arXiv API with retry + rate-limit handling.
+
+    Returns ``(entries, total_results)`` or ``None`` if all retries fail.
+    """
+    for attempt in range(max_retries):
+        try:
+            resp = await client.get(url)
+            if resp.status_code == 429:
+                retry_after = resp.headers.get("Retry-After")
+                wait = (
+                    int(retry_after)
+                    if retry_after
+                    else backoff * (2**attempt)
+                )
+                print(
+                    f"  429 rate limited, waiting {wait}s "
+                    f"(attempt {attempt + 1}/{max_retries})"
+                )
+                await asyncio.sleep(wait)
+                continue
+            resp.raise_for_status()
+            feed = feedparser.parse(resp.text)
+            total = int(
+                feed.feed.get("opensearch_totalresults", 0)
+            ) or None
+            return feed.entries, total
+        except Exception as e:
+            wait = backoff * (2**attempt)
+            print(
+                f"  API error (attempt {attempt + 1}/{max_retries}): {type(e).__name__}: {e}"
+            )
+            if attempt < max_retries - 1:
+                await asyncio.sleep(wait)
+
+    print(f"  API fetch failed after {max_retries} attempts")
+    return None
+
+
+def _get_announcement_window(target_date):
+    """Map a calendar date to its arXiv submission window.
+
+    arXiv announces new papers Sunday–Thursday at 20:00 ET.  Each
+    announcement covers a specific submission window:
+
+        Submissions received (ET)          Announced (ET)
+        ─────────────────────────          ──────────────
+        Monday 14:00 – Tuesday 14:00       Tuesday 20:00
+        Tuesday 14:00 – Wednesday 14:00    Wednesday 20:00
+        Wednesday 14:00 – Thursday 14:00   Thursday 20:00
+        Thursday 14:00 – Friday 14:00      Sunday 20:00
+        Friday 14:00 – Monday 14:00        Monday 20:00
+
+    Returns ``(start_utc, end_utc)`` or ``None`` for days with no
+    announcement (Friday / Saturday).
+    """
+    eastern = ZoneInfo("America/New_York")
+    dow = target_date.weekday()  # 0=Mon … 6=Sun
+
+    if dow in (4, 5):  # Friday or Saturday — no announcement
+        return None
+
+    if dow == 6:  # Sunday: covers Thu 14:00 → Fri 14:00
+        end_day = target_date - timedelta(days=2)  # Friday
+        start_day = target_date - timedelta(days=3)  # Thursday
+    elif dow == 0:  # Monday: covers Fri 14:00 → Mon 14:00
+        end_day = target_date  # Monday
+        start_day = target_date - timedelta(days=3)  # Friday
+    else:  # Tue–Thu: previous day 14:00 → current day 14:00
+        end_day = target_date
+        start_day = target_date - timedelta(days=1)
+
+    start_dt = datetime(
+        year=start_day.year,
+        month=start_day.month,
+        day=start_day.day,
+        hour=14, minute=0, second=0,
+        tzinfo=eastern,
+    )
+    end_dt = datetime(
+        year=end_day.year,
+        month=end_day.month,
+        day=end_day.day,
+        hour=14, minute=0, second=0,
+        tzinfo=eastern,
+    )
+    return start_dt.astimezone(timezone.utc), end_dt.astimezone(timezone.utc)

--- a/packages/preprint_sources/src/preprint_sources/arxiv.py
+++ b/packages/preprint_sources/src/preprint_sources/arxiv.py
@@ -8,6 +8,7 @@ backfilling historical dates).
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from datetime import datetime, timedelta, timezone
 from typing import List
@@ -30,6 +31,8 @@ _API_BASE = "https://export.arxiv.org/api/query"
 
 # Reused across calls; converts LaTeX text markup (e.g. ``\'e``) to Unicode.
 _LATEX2TEXT = LatexNodes2Text()
+
+logger = logging.getLogger(__name__)
 
 
 class ArxivSource(PreprintSource):
@@ -71,9 +74,9 @@ class ArxivSource(PreprintSource):
         cat_str = "+".join(categories)
         url = f"{_RSS_BASE}/{cat_str}"
 
-        print(f"\nFetching latest arXiv papers via RSS")
-        print(f"  Feed: {url}")
-        print(f"  Categories: {categories}")
+        logger.info(f"\nFetching latest arXiv papers via RSS")
+        logger.info(f"  Feed: {url}")
+        logger.info(f"  Categories: {categories}")
 
         async with httpx.AsyncClient(
             timeout=30, headers={"User-Agent": USER_AGENT}
@@ -118,7 +121,7 @@ class ArxivSource(PreprintSource):
                 )
             )
 
-        print(f"  Found {len(entries)} new papers")
+        logger.info(f"  Found {len(entries)} new papers")
         return entries
 
     # ── API with submission windows (backfill) ─────────────────────
@@ -135,7 +138,7 @@ class ArxivSource(PreprintSource):
         """
         window = _get_announcement_window(target_date)
         if window is None:
-            print(
+            logger.info(
                 f"\nNo arXiv announcement on "
                 f"{target_date.strftime('%A %Y-%m-%d')} — skipping fetch."
             )
@@ -145,12 +148,12 @@ class ArxivSource(PreprintSource):
         start = start_dt.strftime("%Y%m%d%H%M")
         end = end_dt.strftime("%Y%m%d%H%M")
 
-        print(
+        logger.info(
             f"\nFetching arXiv papers via API for "
             f"{target_date.strftime('%A %Y-%m-%d')}"
         )
-        print(f"  Submission window: {start_dt} → {end_dt} (UTC)")
-        print(f"  Categories: {categories}")
+        logger.info(f"  Submission window: {start_dt} → {end_dt} (UTC)")
+        logger.info(f"  Categories: {categories}")
 
         entries: List[PaperEntry] = []
         seen_ids: set[str] = set()
@@ -165,8 +168,8 @@ class ArxivSource(PreprintSource):
 
             papers = await _api_fetch_all(client, query)
             for item in papers:
-                arxiv_id = item.id.split("/")[-1]
-                if arxiv_id in seen_ids:
+                arxiv_id = _extract_arxiv_id(item.id)
+                if not arxiv_id or arxiv_id in seen_ids:
                     continue
                 seen_ids.add(arxiv_id)
 
@@ -191,7 +194,7 @@ class ArxivSource(PreprintSource):
                     )
                 )
 
-        print(f"  Total: {len(entries)} new papers")
+        logger.info(f"  Total: {len(entries)} new papers")
         return entries
 
 
@@ -231,7 +234,7 @@ def _latex_to_unicode(text: str) -> str:
     try:
         return _LATEX2TEXT.latex_to_text(text).strip()
     except Exception as e:
-        print(f"Could not convert assumed LaTeX {text} to unicode")
+        logger.info(f"Could not convert assumed LaTeX {text} to unicode")
         return text
 
 
@@ -299,7 +302,7 @@ async def _api_fetch_all(
         if total is None:
             total = feed_total
             if total is not None and total > page_size:
-                print(f"  {total} total results, paginating...")
+                logger.info(f"  {total} total results, paginating...")
 
         # Stop if we got fewer than a full page or we've fetched everything
         if len(feed_entries) < page_size:
@@ -310,7 +313,7 @@ async def _api_fetch_all(
         offset += page_size
         await asyncio.sleep(5)  # polite delay between pages
 
-    print(f"  Fetched {len(all_entries)} papers via API")
+    logger.info(f"  Fetched {len(all_entries)} papers via API")
     return all_entries
 
 
@@ -334,7 +337,7 @@ async def _api_fetch_page(
                     if retry_after
                     else backoff * (2**attempt)
                 )
-                print(
+                logger.info(
                     f"  429 rate limited, waiting {wait}s "
                     f"(attempt {attempt + 1}/{max_retries})"
                 )
@@ -348,13 +351,13 @@ async def _api_fetch_page(
             return feed.entries, total
         except Exception as e:
             wait = backoff * (2**attempt)
-            print(
+            logger.info(
                 f"  API error (attempt {attempt + 1}/{max_retries}): {type(e).__name__}: {e}"
             )
             if attempt < max_retries - 1:
                 await asyncio.sleep(wait)
 
-    print(f"  API fetch failed after {max_retries} attempts")
+    logger.info(f"  API fetch failed after {max_retries} attempts")
     return None
 
 

--- a/packages/preprint_sources/src/preprint_sources/base.py
+++ b/packages/preprint_sources/src/preprint_sources/base.py
@@ -1,0 +1,114 @@
+"""Base classes for preprint sources.
+
+Each preprint server (arXiv, bioRxiv, ...) implements PreprintSource so the
+pipeline can fetch new papers and the web app can render category pickers and
+source-aware links without knowing server-specific details.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class PaperEntry:
+    """Normalized paper data from any preprint source.
+
+    Every source converts its native format (RSS, API JSON, ...) into this
+    common shape before the pipeline touches it.
+    """
+    source_id: str          # server-specific id, e.g. "2401.12345" or a DOI
+    title: str
+    abstract: str
+    url: str                # landing page (abstract URL)
+    pdf_url: str            # direct link to the PDF
+    authors: List[str]
+    categories: List[str]   # in this source's taxonomy
+    published: str          # ISO datetime string (original submission)
+    source: str             # "arxiv", "biorxiv", ...
+    metadata: dict = field(default_factory=dict)  # extra server-specific data
+
+
+class PreprintSource(ABC):
+    """Interface for a preprint server.
+
+    Required: ``name``, ``label``, ``fetch_latest``, ``landing_url``,
+    ``category_tree``, ``leaf_codes``. The rest are optional capabilities a
+    source declares support for and implements: ``fetch_by_date``, ``search``,
+    and add-by-id (``normalize_id`` / ``fetch_one``).
+    """
+
+    # ── identity ───────────────────────────────────────────────────
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Short identifier stored on each paper, e.g. ``'arxiv'``."""
+        ...
+
+    @property
+    @abstractmethod
+    def label(self) -> str:
+        """Human-facing name for UI badges, e.g. ``'arXiv'``."""
+        ...
+
+    # ── fetching ───────────────────────────────────────────────────
+
+    @abstractmethod
+    async def fetch_latest(self, categories: List[str]) -> List[PaperEntry]:
+        """Fetch papers from the most recent announcement."""
+        ...
+
+    async def fetch_by_date(
+        self, target_date, categories: List[str]
+    ) -> List[PaperEntry]:
+        """Fetch papers for a specific historical date (optional)."""
+        raise NotImplementedError(
+            f"{self.name} does not support fetching by date"
+        )
+
+    # ── identity URLs ──────────────────────────────────────────────
+
+    @abstractmethod
+    def landing_url(self, source_id: str) -> str:
+        """Abstract/landing page URL for a paper id."""
+        ...
+
+    # ── taxonomy ───────────────────────────────────────────────────
+
+    @abstractmethod
+    def category_tree(self) -> List[Dict]:
+        """Nested tree for the UI picker: ``[{label, value, children?}]``."""
+        ...
+
+    @abstractmethod
+    def leaf_codes(self) -> set:
+        """Valid leaf category codes, for form validation."""
+        ...
+
+    def label_for(self, code: str) -> str:
+        """Human label for a category code (defaults to the code itself)."""
+        return code
+
+    # ── search (optional) ──────────────────────────────────────────
+
+    def supports_search(self) -> bool:
+        return False
+
+    async def search(
+        self, *, title: str = "", author: str = ""
+    ) -> List[PaperEntry]:
+        raise NotImplementedError(f"{self.name} does not support search")
+
+    # ── add by id (optional) ───────────────────────────────────────
+
+    def supports_add_by_id(self) -> bool:
+        return False
+
+    def normalize_id(self, raw: str) -> Optional[str]:
+        """Parse a user-typed id/DOI/URL into a canonical source_id, or None."""
+        raise NotImplementedError(f"{self.name} does not support add-by-id")
+
+    async def fetch_one(self, source_id: str) -> Optional[PaperEntry]:
+        raise NotImplementedError(f"{self.name} does not support add-by-id")

--- a/packages/preprint_sources/src/preprint_sources/registry.py
+++ b/packages/preprint_sources/src/preprint_sources/registry.py
@@ -33,7 +33,8 @@ def enabled_names() -> List[str]:
     Unknown names in the env var are ignored.
     """
     raw = os.environ.get("PREPRINT_ENABLED_SOURCES", "arxiv")
-    return [n.strip() for n in raw.split(",") if n.strip() in _CLASSES]
+    names = [n.strip() for n in raw.split(",") if n.strip() in _CLASSES]
+    return list(dict.fromkeys(names))
 
 
 def enabled_sources() -> List[PreprintSource]:

--- a/packages/preprint_sources/src/preprint_sources/registry.py
+++ b/packages/preprint_sources/src/preprint_sources/registry.py
@@ -1,0 +1,41 @@
+"""Registry of available preprint sources.
+
+Adding a source: implement PreprintSource in a new module, then add it to
+``_CLASSES`` below. Enablement is env-driven (PREPRINT_ENABLED_SOURCES) so
+every consumer resolves the same set.
+"""
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Type
+
+from .arxiv import ArxivSource
+from .base import PreprintSource
+
+_CLASSES: Dict[str, Type[PreprintSource]] = {
+    "arxiv": ArxivSource,
+}
+
+
+def all_source_names() -> List[str]:
+    """Every registered source name, in registration order."""
+    return list(_CLASSES)
+
+
+def get_source(name: str) -> PreprintSource:
+    """Instantiate a source by name. Raises KeyError if unknown."""
+    return _CLASSES[name]()
+
+
+def enabled_names() -> List[str]:
+    """Sources turned on via PREPRINT_ENABLED_SOURCES (default: ``arxiv``).
+
+    Unknown names in the env var are ignored.
+    """
+    raw = os.environ.get("PREPRINT_ENABLED_SOURCES", "arxiv")
+    return [n.strip() for n in raw.split(",") if n.strip() in _CLASSES]
+
+
+def enabled_sources() -> List[PreprintSource]:
+    """Instantiated sources that are currently enabled."""
+    return [_CLASSES[n]() for n in enabled_names()]

--- a/packages/preprint_sources/src/preprint_sources/settings.py
+++ b/packages/preprint_sources/src/preprint_sources/settings.py
@@ -1,0 +1,9 @@
+"""Runtime settings for preprint sources (env-overridable).
+
+Self-contained so the package has no dependency on preprint_bot.config.
+"""
+import os
+
+# Sent as the User-Agent header on outbound requests to preprint servers.
+# Override with the PREPRINT_SOURCES_USER_AGENT environment variable.
+USER_AGENT = os.environ.get("PREPRINT_SOURCES_USER_AGENT", "PreprintBot/1.0")

--- a/packages/preprint_sources/src/preprint_sources/taxonomies/__init__.py
+++ b/packages/preprint_sources/src/preprint_sources/taxonomies/__init__.py
@@ -1,0 +1,1 @@
+"""Per-source category taxonomies (nested trees for the UI picker)."""

--- a/packages/preprint_sources/src/preprint_sources/taxonomies/arxiv.py
+++ b/packages/preprint_sources/src/preprint_sources/taxonomies/arxiv.py
@@ -1,0 +1,296 @@
+"""
+arXiv category taxonomy – flat list and nested tree structure.
+
+Used by the profile form's category-picker widget.
+The tree mirrors the Streamlit app's ARXIV_CATEGORY_TREE exactly,
+with "title" renamed to "label" for the Django JS picker.
+"""
+
+from typing import Dict, List
+
+# Nested tree used by the JavaScript category picker
+ARXIV_CATEGORY_TREE: List[Dict] = [
+    {
+        "label": "Computer Science",
+        "value": "cs",
+        "children": [
+            {"label": "Artificial Intelligence (cs.AI)", "value": "cs.AI"},
+            {"label": "Hardware Architecture (cs.AR)", "value": "cs.AR"},
+            {"label": "Computational Complexity (cs.CC)", "value": "cs.CC"},
+            {"label": "Computational Engineering, Finance, and Science (cs.CE)", "value": "cs.CE"},
+            {"label": "Computational Geometry (cs.CG)", "value": "cs.CG"},
+            {"label": "Computation and Language (cs.CL)", "value": "cs.CL"},
+            {"label": "Cryptography and Security (cs.CR)", "value": "cs.CR"},
+            {"label": "Computer Vision and Pattern Recognition (cs.CV)", "value": "cs.CV"},
+            {"label": "Computers and Society (cs.CY)", "value": "cs.CY"},
+            {"label": "Databases (cs.DB)", "value": "cs.DB"},
+            {"label": "Distributed, Parallel, and Cluster Computing (cs.DC)", "value": "cs.DC"},
+            {"label": "Digital Libraries (cs.DL)", "value": "cs.DL"},
+            {"label": "Discrete Mathematics (cs.DM)", "value": "cs.DM"},
+            {"label": "Data Structures and Algorithms (cs.DS)", "value": "cs.DS"},
+            {"label": "Emerging Technologies (cs.ET)", "value": "cs.ET"},
+            {"label": "Formal Languages and Automata Theory (cs.FL)", "value": "cs.FL"},
+            {"label": "General Literature (cs.GL)", "value": "cs.GL"},
+            {"label": "Graphics (cs.GR)", "value": "cs.GR"},
+            {"label": "Computer Science and Game Theory (cs.GT)", "value": "cs.GT"},
+            {"label": "Human-Computer Interaction (cs.HC)", "value": "cs.HC"},
+            {"label": "Information Retrieval (cs.IR)", "value": "cs.IR"},
+            {"label": "Information Theory (cs.IT)", "value": "cs.IT"},
+            {"label": "Machine Learning (cs.LG)", "value": "cs.LG"},
+            {"label": "Logic in Computer Science (cs.LO)", "value": "cs.LO"},
+            {"label": "Multiagent Systems (cs.MA)", "value": "cs.MA"},
+            {"label": "Multimedia (cs.MM)", "value": "cs.MM"},
+            {"label": "Mathematical Software (cs.MS)", "value": "cs.MS"},
+            {"label": "Numerical Analysis (cs.NA)", "value": "cs.NA"},
+            {"label": "Neural and Evolutionary Computing (cs.NE)", "value": "cs.NE"},
+            {"label": "Networking and Internet Architecture (cs.NI)", "value": "cs.NI"},
+            {"label": "Other Computer Science (cs.OH)", "value": "cs.OH"},
+            {"label": "Operating Systems (cs.OS)", "value": "cs.OS"},
+            {"label": "Performance (cs.PF)", "value": "cs.PF"},
+            {"label": "Programming Languages (cs.PL)", "value": "cs.PL"},
+            {"label": "Robotics (cs.RO)", "value": "cs.RO"},
+            {"label": "Symbolic Computation (cs.SC)", "value": "cs.SC"},
+            {"label": "Sound (cs.SD)", "value": "cs.SD"},
+            {"label": "Software Engineering (cs.SE)", "value": "cs.SE"},
+            {"label": "Social and Information Networks (cs.SI)", "value": "cs.SI"},
+            {"label": "Systems and Control (cs.SY)", "value": "cs.SY"},
+        ],
+    },
+    {
+        "label": "Economics",
+        "value": "econ",
+        "children": [
+            {"label": "Econometrics (econ.EM)", "value": "econ.EM"},
+            {"label": "General Economics (econ.GN)", "value": "econ.GN"},
+            {"label": "Theoretical Economics (econ.TH)", "value": "econ.TH"},
+        ],
+    },
+    {
+        "label": "Electrical Engineering and Systems Science",
+        "value": "eess",
+        "children": [
+            {"label": "Audio and Speech Processing (eess.AS)", "value": "eess.AS"},
+            {"label": "Image and Video Processing (eess.IV)", "value": "eess.IV"},
+            {"label": "Signal Processing (eess.SP)", "value": "eess.SP"},
+            {"label": "Systems and Control (eess.SY)", "value": "eess.SY"},
+        ],
+    },
+    {
+        "label": "Mathematics",
+        "value": "math",
+        "children": [
+            {"label": "Commutative Algebra (math.AC)", "value": "math.AC"},
+            {"label": "Algebraic Geometry (math.AG)", "value": "math.AG"},
+            {"label": "Analysis of PDEs (math.AP)", "value": "math.AP"},
+            {"label": "Algebraic Topology (math.AT)", "value": "math.AT"},
+            {"label": "Classical Analysis and ODEs (math.CA)", "value": "math.CA"},
+            {"label": "Combinatorics (math.CO)", "value": "math.CO"},
+            {"label": "Category Theory (math.CT)", "value": "math.CT"},
+            {"label": "Complex Variables (math.CV)", "value": "math.CV"},
+            {"label": "Differential Geometry (math.DG)", "value": "math.DG"},
+            {"label": "Dynamical Systems (math.DS)", "value": "math.DS"},
+            {"label": "Functional Analysis (math.FA)", "value": "math.FA"},
+            {"label": "General Mathematics (math.GM)", "value": "math.GM"},
+            {"label": "General Topology (math.GN)", "value": "math.GN"},
+            {"label": "Group Theory (math.GR)", "value": "math.GR"},
+            {"label": "Geometric Topology (math.GT)", "value": "math.GT"},
+            {"label": "History and Overview (math.HO)", "value": "math.HO"},
+            {"label": "Information Theory (math.IT)", "value": "math.IT"},
+            {"label": "K-Theory and Homology (math.KT)", "value": "math.KT"},
+            {"label": "Logic (math.LO)", "value": "math.LO"},
+            {"label": "Metric Geometry (math.MG)", "value": "math.MG"},
+            {"label": "Mathematical Physics (math.MP)", "value": "math.MP"},
+            {"label": "Numerical Analysis (math.NA)", "value": "math.NA"},
+            {"label": "Number Theory (math.NT)", "value": "math.NT"},
+            {"label": "Operator Algebras (math.OA)", "value": "math.OA"},
+            {"label": "Optimization and Control (math.OC)", "value": "math.OC"},
+            {"label": "Probability (math.PR)", "value": "math.PR"},
+            {"label": "Quantum Algebra (math.QA)", "value": "math.QA"},
+            {"label": "Rings and Algebras (math.RA)", "value": "math.RA"},
+            {"label": "Representation Theory (math.RT)", "value": "math.RT"},
+            {"label": "Symplectic Geometry (math.SG)", "value": "math.SG"},
+            {"label": "Spectral Theory (math.SP)", "value": "math.SP"},
+            {"label": "Statistics Theory (math.ST)", "value": "math.ST"},
+        ],
+    },
+    {
+        "label": "Physics",
+        "value": "physics_group",
+        "children": [
+            {
+                "label": "Astrophysics",
+                "value": "astro-ph",
+                "children": [
+                    {"label": "Cosmology and Nongalactic Astrophysics (astro-ph.CO)", "value": "astro-ph.CO"},
+                    {"label": "Earth and Planetary Astrophysics (astro-ph.EP)", "value": "astro-ph.EP"},
+                    {"label": "Astrophysics of Galaxies (astro-ph.GA)", "value": "astro-ph.GA"},
+                    {"label": "High Energy Astrophysical Phenomena (astro-ph.HE)", "value": "astro-ph.HE"},
+                    {"label": "Instrumentation and Methods for Astrophysics (astro-ph.IM)", "value": "astro-ph.IM"},
+                    {"label": "Solar and Stellar Astrophysics (astro-ph.SR)", "value": "astro-ph.SR"},
+                ],
+            },
+            {
+                "label": "Condensed Matter",
+                "value": "cond-mat",
+                "children": [
+                    {"label": "Disordered Systems and Neural Networks (cond-mat.dis-nn)", "value": "cond-mat.dis-nn"},
+                    {"label": "Mesoscale and Nanoscale Physics (cond-mat.mes-hall)", "value": "cond-mat.mes-hall"},
+                    {"label": "Materials Science (cond-mat.mtrl-sci)", "value": "cond-mat.mtrl-sci"},
+                    {"label": "Other Condensed Matter (cond-mat.other)", "value": "cond-mat.other"},
+                    {"label": "Quantum Gases (cond-mat.quant-gas)", "value": "cond-mat.quant-gas"},
+                    {"label": "Soft Condensed Matter (cond-mat.soft)", "value": "cond-mat.soft"},
+                    {"label": "Statistical Mechanics (cond-mat.stat-mech)", "value": "cond-mat.stat-mech"},
+                    {"label": "Strongly Correlated Electrons (cond-mat.str-el)", "value": "cond-mat.str-el"},
+                    {"label": "Superconductivity (cond-mat.supr-con)", "value": "cond-mat.supr-con"},
+                ],
+            },
+            {
+                "label": "High Energy Physics",
+                "value": "hep",
+                "children": [
+                    {"label": "High Energy Physics – Experiment (hep-ex)", "value": "hep-ex"},
+                    {"label": "High Energy Physics – Lattice (hep-lat)", "value": "hep-lat"},
+                    {"label": "High Energy Physics – Phenomenology (hep-ph)", "value": "hep-ph"},
+                    {"label": "High Energy Physics – Theory (hep-th)", "value": "hep-th"},
+                ],
+            },
+            {
+                "label": "Nonlinear Sciences",
+                "value": "nlin",
+                "children": [
+                    {"label": "Adaptation and Self-Organizing Systems (nlin.AO)", "value": "nlin.AO"},
+                    {"label": "Chaotic Dynamics (nlin.CD)", "value": "nlin.CD"},
+                    {"label": "Cellular Automata and Lattice Gases (nlin.CG)", "value": "nlin.CG"},
+                    {"label": "Pattern Formation and Solitons (nlin.PS)", "value": "nlin.PS"},
+                    {"label": "Exactly Solvable and Integrable Systems (nlin.SI)", "value": "nlin.SI"},
+                ],
+            },
+            {
+                "label": "Physics (General)",
+                "value": "physics",
+                "children": [
+                    {"label": "Accelerator Physics (physics.acc-ph)", "value": "physics.acc-ph"},
+                    {"label": "Atmospheric and Oceanic Physics (physics.ao-ph)", "value": "physics.ao-ph"},
+                    {"label": "Applied Physics (physics.app-ph)", "value": "physics.app-ph"},
+                    {"label": "Atomic and Molecular Clusters (physics.atm-clus)", "value": "physics.atm-clus"},
+                    {"label": "Atomic Physics (physics.atom-ph)", "value": "physics.atom-ph"},
+                    {"label": "Biological Physics (physics.bio-ph)", "value": "physics.bio-ph"},
+                    {"label": "Chemical Physics (physics.chem-ph)", "value": "physics.chem-ph"},
+                    {"label": "Classical Physics (physics.class-ph)", "value": "physics.class-ph"},
+                    {"label": "Computational Physics (physics.comp-ph)", "value": "physics.comp-ph"},
+                    {"label": "Data Analysis, Statistics and Probability (physics.data-an)", "value": "physics.data-an"},
+                    {"label": "Physics Education (physics.ed-ph)", "value": "physics.ed-ph"},
+                    {"label": "Fluid Dynamics (physics.flu-dyn)", "value": "physics.flu-dyn"},
+                    {"label": "General Physics (physics.gen-ph)", "value": "physics.gen-ph"},
+                    {"label": "Geophysics (physics.geo-ph)", "value": "physics.geo-ph"},
+                    {"label": "History and Philosophy of Physics (physics.hist-ph)", "value": "physics.hist-ph"},
+                    {"label": "Instrumentation and Detectors (physics.ins-det)", "value": "physics.ins-det"},
+                    {"label": "Medical Physics (physics.med-ph)", "value": "physics.med-ph"},
+                    {"label": "Optics (physics.optics)", "value": "physics.optics"},
+                    {"label": "Plasma Physics (physics.plasm-ph)", "value": "physics.plasm-ph"},
+                    {"label": "Popular Physics (physics.pop-ph)", "value": "physics.pop-ph"},
+                    {"label": "Physics and Society (physics.soc-ph)", "value": "physics.soc-ph"},
+                    {"label": "Space Physics (physics.space-ph)", "value": "physics.space-ph"},
+                ],
+            },
+            {
+                "label": "Other Physics",
+                "value": "other-physics",
+                "children": [
+                    {"label": "General Relativity and Quantum Cosmology (gr-qc)", "value": "gr-qc"},
+                    {"label": "Mathematical Physics (math-ph)", "value": "math-ph"},
+                    {"label": "Nuclear Experiment (nucl-ex)", "value": "nucl-ex"},
+                    {"label": "Nuclear Theory (nucl-th)", "value": "nucl-th"},
+                    {"label": "Quantum Physics (quant-ph)", "value": "quant-ph"},
+                ],
+            },
+        ],
+    },
+    {
+        "label": "Quantitative Biology",
+        "value": "q-bio",
+        "children": [
+            {"label": "Biomolecules (q-bio.BM)", "value": "q-bio.BM"},
+            {"label": "Cell Behavior (q-bio.CB)", "value": "q-bio.CB"},
+            {"label": "Genomics (q-bio.GN)", "value": "q-bio.GN"},
+            {"label": "Molecular Networks (q-bio.MN)", "value": "q-bio.MN"},
+            {"label": "Neurons and Cognition (q-bio.NC)", "value": "q-bio.NC"},
+            {"label": "Other Quantitative Biology (q-bio.OT)", "value": "q-bio.OT"},
+            {"label": "Populations and Evolution (q-bio.PE)", "value": "q-bio.PE"},
+            {"label": "Quantitative Methods (q-bio.QM)", "value": "q-bio.QM"},
+            {"label": "Subcellular Processes (q-bio.SC)", "value": "q-bio.SC"},
+            {"label": "Tissues and Organs (q-bio.TO)", "value": "q-bio.TO"},
+        ],
+    },
+    {
+        "label": "Quantitative Finance",
+        "value": "q-fin",
+        "children": [
+            {"label": "Computational Finance (q-fin.CP)", "value": "q-fin.CP"},
+            {"label": "Economics (q-fin.EC)", "value": "q-fin.EC"},
+            {"label": "General Finance (q-fin.GN)", "value": "q-fin.GN"},
+            {"label": "Mathematical Finance (q-fin.MF)", "value": "q-fin.MF"},
+            {"label": "Portfolio Management (q-fin.PM)", "value": "q-fin.PM"},
+            {"label": "Pricing of Securities (q-fin.PR)", "value": "q-fin.PR"},
+            {"label": "Risk Management (q-fin.RM)", "value": "q-fin.RM"},
+            {"label": "Statistical Finance (q-fin.ST)", "value": "q-fin.ST"},
+            {"label": "Trading and Market Microstructure (q-fin.TR)", "value": "q-fin.TR"},
+        ],
+    },
+    {
+        "label": "Statistics",
+        "value": "stat",
+        "children": [
+            {"label": "Applications (stat.AP)", "value": "stat.AP"},
+            {"label": "Computation (stat.CO)", "value": "stat.CO"},
+            {"label": "Methodology (stat.ME)", "value": "stat.ME"},
+            {"label": "Machine Learning (stat.ML)", "value": "stat.ML"},
+            {"label": "Other Statistics (stat.OT)", "value": "stat.OT"},
+            {"label": "Statistics Theory (stat.TH)", "value": "stat.TH"},
+        ],
+    },
+]
+
+
+def _build_code_to_label() -> Dict[str, str]:
+    """Build a flat code → human-readable label mapping."""
+    out: Dict[str, str] = {}
+
+    def walk(nodes):
+        for node in nodes:
+            v = node.get("value", "")
+            lbl = node.get("label", v)
+            if v:
+                out[v] = lbl
+            for ch in node.get("children", []):
+                walk([ch])
+
+    walk(ARXIV_CATEGORY_TREE)
+    return out
+
+
+ARXIV_CODE_TO_LABEL: Dict[str, str] = _build_code_to_label()
+
+
+def _build_leaf_codes() -> set:
+    """Return the set of leaf category codes (no children in the tree)."""
+    leaves: set = set()
+
+    def walk(nodes):
+        for node in nodes:
+            children = node.get("children", [])
+            if children:
+                walk(children)
+            elif node.get("value"):
+                leaves.add(node["value"])
+
+    walk(ARXIV_CATEGORY_TREE)
+    return leaves
+
+
+ARXIV_LEAF_CODES: set = _build_leaf_codes()
+
+
+def label_for(code: str) -> str:
+    """Return the human-readable label for an arXiv category code."""
+    return ARXIV_CODE_TO_LABEL.get(code, code)

--- a/packages/preprint_sources/src/preprint_sources/taxonomies/arxiv.py
+++ b/packages/preprint_sources/src/preprint_sources/taxonomies/arxiv.py
@@ -262,8 +262,7 @@ def _build_code_to_label() -> Dict[str, str]:
             lbl = node.get("label", v)
             if v:
                 out[v] = lbl
-            for ch in node.get("children", []):
-                walk([ch])
+            walk(node.get("children", []))
 
     walk(ARXIV_CATEGORY_TREE)
     return out

--- a/packages/preprint_sources/tests/test_arxiv_fetch.py
+++ b/packages/preprint_sources/tests/test_arxiv_fetch.py
@@ -109,10 +109,10 @@ class TestFetchByDate:
         papers = await ArxivSource().fetch_by_date(date(2024, 1, 2), ["cs.SE"])
         assert len(papers) == 1
         p = papers[0]
-        # API path keeps the version suffix (unlike the RSS path).
-        assert p.source_id == "2401.09999v1"
+        # Version stripped, consistent with the RSS path (fetch_latest).
+        assert p.source_id == "2401.09999"
         assert p.title == "API Paper"
         assert p.abstract == "An abstract."
         assert p.authors == ["Grace Hopper"]
         assert p.categories == ["cs.SE"]
-        assert p.pdf_url == "https://arxiv.org/pdf/2401.09999v1.pdf"
+        assert p.pdf_url == "https://arxiv.org/pdf/2401.09999.pdf"

--- a/packages/preprint_sources/tests/test_arxiv_fetch.py
+++ b/packages/preprint_sources/tests/test_arxiv_fetch.py
@@ -1,0 +1,118 @@
+"""Tests for ArxivSource.fetch_latest / fetch_by_date with the network mocked."""
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from preprint_sources import ArxivSource
+
+
+def _feed(entries):
+    return SimpleNamespace(entries=entries, feed={})
+
+
+def _mock_async_client():
+    """A stand-in for httpx.AsyncClient usable as an async context manager."""
+    client = AsyncMock()
+    client.get.return_value = Mock(text="<rss/>", status_code=200,
+                                   headers={}, raise_for_status=Mock())
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _rss_item(link, announce="new", title="arXiv:x A Title",
+              description="<p>Body.</p>", author="Ada Lovelace", tags=("cs.AI",)):
+    return SimpleNamespace(
+        link=link, title=title, description=description,
+        arxiv_announce_type=announce, author=author,
+        tags=[SimpleNamespace(term=t) for t in tags], published="2024-01-02T00:00:00Z",
+    )
+
+
+class TestFetchLatest:
+    @patch("preprint_sources.arxiv.feedparser.parse")
+    @patch("preprint_sources.arxiv.httpx.AsyncClient")
+    async def test_parses_new_item_into_paper_entry(self, mock_client, mock_parse):
+        mock_client.return_value = _mock_async_client()
+        mock_parse.return_value = _feed([
+            _rss_item("https://arxiv.org/abs/2401.00001v2",
+                      title="arXiv:2401.00001 A New Result",
+                      description="<p>We show something.</p>",
+                      author="Ada Lovelace, Alan Turing"),
+        ])
+        papers = await ArxivSource().fetch_latest(["cs.AI"])
+        assert len(papers) == 1
+        p = papers[0]
+        assert p.source_id == "2401.00001"                       # version stripped
+        assert p.title == "A New Result"                         # arXiv: prefix stripped
+        assert p.abstract == "We show something."                # HTML stripped
+        assert p.pdf_url == "https://arxiv.org/pdf/2401.00001.pdf"
+        assert p.authors == ["Ada Lovelace", "Alan Turing"]
+        assert p.categories == ["cs.AI"]
+        assert p.source == "arxiv"
+
+    @patch("preprint_sources.arxiv.feedparser.parse")
+    @patch("preprint_sources.arxiv.httpx.AsyncClient")
+    async def test_skips_non_new_announce_types(self, mock_client, mock_parse):
+        mock_client.return_value = _mock_async_client()
+        mock_parse.return_value = _feed([
+            _rss_item("https://arxiv.org/abs/2401.00001", announce="new"),
+            _rss_item("https://arxiv.org/abs/2401.00002", announce="replace"),
+            _rss_item("https://arxiv.org/abs/2401.00003", announce="cross"),
+        ])
+        papers = await ArxivSource().fetch_latest(["cs.AI"])
+        assert [p.source_id for p in papers] == ["2401.00001"]
+
+    @patch("preprint_sources.arxiv.feedparser.parse")
+    @patch("preprint_sources.arxiv.httpx.AsyncClient")
+    async def test_dedupes_by_arxiv_id(self, mock_client, mock_parse):
+        mock_client.return_value = _mock_async_client()
+        mock_parse.return_value = _feed([
+            _rss_item("https://arxiv.org/abs/2401.00001v1"),
+            _rss_item("https://arxiv.org/abs/2401.00001v2"),   # same id, other version
+        ])
+        papers = await ArxivSource().fetch_latest(["cs.AI"])
+        assert len(papers) == 1
+
+    @patch("preprint_sources.arxiv.feedparser.parse")
+    @patch("preprint_sources.arxiv.httpx.AsyncClient")
+    async def test_skips_items_without_arxiv_id(self, mock_client, mock_parse):
+        mock_client.return_value = _mock_async_client()
+        mock_parse.return_value = _feed([_rss_item("https://example.com/no-abs")])
+        assert await ArxivSource().fetch_latest(["cs.AI"]) == []
+
+
+class TestFetchByDate:
+    @patch("preprint_sources.arxiv._get_announcement_window", return_value=None)
+    async def test_no_announcement_returns_empty(self, _mock_window):
+        # Friday has no announcement window -> returns before any network call.
+        assert await ArxivSource().fetch_by_date(date(2024, 1, 5), ["cs.AI"]) == []
+
+    @patch("preprint_sources.arxiv._api_fetch_all")
+    @patch("preprint_sources.arxiv.httpx.AsyncClient")
+    @patch("preprint_sources.arxiv._get_announcement_window")
+    async def test_builds_entries_from_api(self, mock_window, mock_client, mock_fetch_all):
+        mock_window.return_value = (
+            datetime(2024, 1, 1, tzinfo=timezone.utc),
+            datetime(2024, 1, 2, tzinfo=timezone.utc),
+        )
+        mock_client.return_value = _mock_async_client()
+        mock_fetch_all.return_value = [SimpleNamespace(
+            id="http://arxiv.org/abs/2401.09999v1",
+            title="  API Paper  ",
+            summary="  An abstract.  ",
+            authors=[SimpleNamespace(name="Grace Hopper")],
+            tags=[SimpleNamespace(term="cs.SE")],
+            published="2024-01-01T00:00:00Z",
+        )]
+        papers = await ArxivSource().fetch_by_date(date(2024, 1, 2), ["cs.SE"])
+        assert len(papers) == 1
+        p = papers[0]
+        # API path keeps the version suffix (unlike the RSS path).
+        assert p.source_id == "2401.09999v1"
+        assert p.title == "API Paper"
+        assert p.abstract == "An abstract."
+        assert p.authors == ["Grace Hopper"]
+        assert p.categories == ["cs.SE"]
+        assert p.pdf_url == "https://arxiv.org/pdf/2401.09999v1.pdf"

--- a/packages/preprint_sources/tests/test_arxiv_parsing.py
+++ b/packages/preprint_sources/tests/test_arxiv_parsing.py
@@ -1,0 +1,103 @@
+"""Unit tests for the pure arXiv parsing + date-window helpers."""
+from datetime import date, timedelta
+from types import SimpleNamespace
+
+from preprint_sources.arxiv import (
+    _clean_html,
+    _clean_rss_title,
+    _extract_arxiv_id,
+    _get_announcement_window,
+    _latex_to_unicode,
+    _parse_rss_authors,
+    _parse_rss_categories,
+)
+
+
+class TestExtractArxivId:
+    def test_basic(self):
+        assert _extract_arxiv_id("https://arxiv.org/abs/2401.12345") == "2401.12345"
+
+    def test_strips_version(self):
+        assert _extract_arxiv_id("https://arxiv.org/abs/2401.12345v3") == "2401.12345"
+
+    def test_no_abs_returns_none(self):
+        assert _extract_arxiv_id("https://example.com/nope") is None
+
+    def test_none_input(self):
+        assert _extract_arxiv_id(None) is None
+
+
+class TestCleanRssTitle:
+    def test_strips_arxiv_prefix(self):
+        assert _clean_rss_title("arXiv:2401.12345 A Great Paper") == "A Great Paper"
+
+    def test_plain_title_unchanged(self):
+        assert _clean_rss_title("A Great Paper") == "A Great Paper"
+
+
+class TestCleanHtml:
+    def test_strips_tags_and_collapses_whitespace(self):
+        assert _clean_html("<p>Hello   <b>world</b></p>") == "Hello world"
+
+
+class TestLatexToUnicode:
+    def test_plain_text_unchanged(self):
+        assert _latex_to_unicode("Ada Lovelace") == "Ada Lovelace"
+
+    def test_apostrophe_not_treated_as_latex(self):
+        # No backslash -> returned as-is (O'Brien must not be mangled).
+        assert _latex_to_unicode("O'Brien") == "O'Brien"
+
+    def test_decodes_latex_accents(self):
+        out = _latex_to_unicode(r"J\'er\^ome")
+        assert "\\" not in out
+        assert "é" in out and "ô" in out
+
+
+class TestParseRssAuthors:
+    def test_comma_joined_single_creator(self):
+        item = SimpleNamespace(author="Ada Lovelace, Alan Turing")
+        assert _parse_rss_authors(item) == ["Ada Lovelace", "Alan Turing"]
+
+    def test_latex_names_decoded(self):
+        item = SimpleNamespace(author=r"J\'er\^ome Dupont, Alan Turing")
+        authors = _parse_rss_authors(item)
+        assert authors[1] == "Alan Turing"
+        assert "\\" not in authors[0] and "é" in authors[0]
+
+    def test_authors_list_field(self):
+        item = SimpleNamespace(authors=[{"name": "Ada Lovelace"}, {"name": "Alan Turing"}])
+        assert _parse_rss_authors(item) == ["Ada Lovelace", "Alan Turing"]
+
+    def test_empty(self):
+        assert _parse_rss_authors(SimpleNamespace(author="")) == []
+
+
+class TestParseRssCategories:
+    def test_from_tags(self):
+        item = SimpleNamespace(tags=[SimpleNamespace(term="cs.AI"), SimpleNamespace(term="cs.LG")])
+        assert _parse_rss_categories(item) == ["cs.AI", "cs.LG"]
+
+    def test_no_tags(self):
+        assert _parse_rss_categories(SimpleNamespace(other=1)) == []
+
+
+class TestAnnouncementWindow:
+    # 2024-01-01 is a Monday, so the weekdays below are known.
+    def test_friday_has_no_announcement(self):
+        assert _get_announcement_window(date(2024, 1, 5)) is None
+
+    def test_saturday_has_no_announcement(self):
+        assert _get_announcement_window(date(2024, 1, 6)) is None
+
+    def test_tuesday_is_a_one_day_window(self):
+        start, end = _get_announcement_window(date(2024, 1, 2))
+        assert end - start == timedelta(days=1)
+
+    def test_sunday_is_a_one_day_window(self):
+        start, end = _get_announcement_window(date(2024, 1, 7))
+        assert end - start == timedelta(days=1)
+
+    def test_monday_covers_the_weekend(self):
+        start, end = _get_announcement_window(date(2024, 1, 8))
+        assert end - start == timedelta(days=3)

--- a/packages/preprint_sources/tests/test_arxiv_source.py
+++ b/packages/preprint_sources/tests/test_arxiv_source.py
@@ -1,0 +1,37 @@
+"""Tests for ArxivSource identity, URLs, and taxonomy (no network)."""
+from preprint_sources import ArxivSource
+
+
+def test_identity():
+    src = ArxivSource()
+    assert src.name == "arxiv"
+    assert src.label == "arXiv"
+
+
+def test_landing_url():
+    assert ArxivSource().landing_url("2401.12345") == "https://arxiv.org/abs/2401.12345"
+
+
+def test_category_tree_is_nested_and_nonempty():
+    tree = ArxivSource().category_tree()
+    assert isinstance(tree, list) and tree
+    top = tree[0]
+    assert {"label", "value"} <= set(top)
+    assert "children" in top and top["children"]      # nested taxonomy
+
+
+def test_leaf_codes_and_labels():
+    src = ArxivSource()
+    codes = src.leaf_codes()
+    assert "cs.AI" in codes
+    assert "cs.LG" in codes
+    # a leaf resolves to a human label distinct from the bare code
+    assert src.label_for("cs.AI") != "cs.AI"
+    # unknown code falls back to itself
+    assert src.label_for("not.a.code") == "not.a.code"
+
+
+def test_optional_capabilities_off_by_default():
+    src = ArxivSource()
+    assert src.supports_search() is False
+    assert src.supports_add_by_id() is False

--- a/packages/preprint_sources/tests/test_base.py
+++ b/packages/preprint_sources/tests/test_base.py
@@ -1,0 +1,71 @@
+"""Tests for the PreprintSource ABC contract and PaperEntry."""
+import pytest
+
+from preprint_sources import PaperEntry, PreprintSource
+
+
+def test_paper_entry_defaults_metadata():
+    e = PaperEntry(
+        source_id="1", title="t", abstract="a", url="u", pdf_url="p",
+        authors=["x"], categories=["c"], published="d", source="arxiv",
+    )
+    assert e.metadata == {}          # default_factory=dict
+
+
+def test_cannot_instantiate_bare_abstract_base():
+    with pytest.raises(TypeError):
+        PreprintSource()
+
+
+def test_incomplete_subclass_cannot_instantiate():
+    class Partial(PreprintSource):
+        @property
+        def name(self):
+            return "partial"
+        # missing label/fetch_latest/landing_url/category_tree/leaf_codes
+
+    with pytest.raises(TypeError):
+        Partial()
+
+
+class _Minimal(PreprintSource):
+    """A complete-but-minimal source for exercising the optional defaults."""
+
+    @property
+    def name(self):
+        return "min"
+
+    @property
+    def label(self):
+        return "Min"
+
+    async def fetch_latest(self, categories):
+        return []
+
+    def landing_url(self, source_id):
+        return source_id
+
+    def category_tree(self):
+        return []
+
+    def leaf_codes(self):
+        return set()
+
+
+def test_optional_capabilities_default_off():
+    src = _Minimal()
+    assert src.supports_search() is False
+    assert src.supports_add_by_id() is False
+    assert src.label_for("code") == "code"
+
+
+async def test_optional_methods_raise_not_implemented():
+    src = _Minimal()
+    with pytest.raises(NotImplementedError):
+        await src.fetch_by_date(None, [])
+    with pytest.raises(NotImplementedError):
+        await src.search(title="x")
+    with pytest.raises(NotImplementedError):
+        src.normalize_id("x")
+    with pytest.raises(NotImplementedError):
+        await src.fetch_one("x")

--- a/packages/preprint_sources/tests/test_registry.py
+++ b/packages/preprint_sources/tests/test_registry.py
@@ -35,3 +35,9 @@ def test_enabled_defaults_to_arxiv(monkeypatch):
 def test_enabled_reads_env_and_drops_unknown(monkeypatch):
     monkeypatch.setenv("PREPRINT_ENABLED_SOURCES", "arxiv, bogus")
     assert enabled_names() == ["arxiv"]
+
+
+def test_enabled_dedupes_preserving_order(monkeypatch):
+    monkeypatch.setenv("PREPRINT_ENABLED_SOURCES", "arxiv, arxiv")
+    assert enabled_names() == ["arxiv"]
+    assert [s.name for s in enabled_sources()] == ["arxiv"]

--- a/packages/preprint_sources/tests/test_registry.py
+++ b/packages/preprint_sources/tests/test_registry.py
@@ -1,0 +1,37 @@
+"""Tests for the source registry."""
+import pytest
+
+from preprint_sources import (
+    ArxivSource,
+    PreprintSource,
+    all_source_names,
+    enabled_names,
+    enabled_sources,
+    get_source,
+)
+
+
+def test_arxiv_is_registered():
+    assert "arxiv" in all_source_names()
+
+
+def test_get_source_returns_instance():
+    src = get_source("arxiv")
+    assert isinstance(src, ArxivSource)
+    assert isinstance(src, PreprintSource)
+
+
+def test_get_unknown_source_raises():
+    with pytest.raises(KeyError):
+        get_source("nope")
+
+
+def test_enabled_defaults_to_arxiv(monkeypatch):
+    monkeypatch.delenv("PREPRINT_ENABLED_SOURCES", raising=False)
+    assert enabled_names() == ["arxiv"]
+    assert [s.name for s in enabled_sources()] == ["arxiv"]
+
+
+def test_enabled_reads_env_and_drops_unknown(monkeypatch):
+    monkeypatch.setenv("PREPRINT_ENABLED_SOURCES", "arxiv, bogus")
+    assert enabled_names() == ["arxiv"]

--- a/packages/preprint_sources/tests/test_settings.py
+++ b/packages/preprint_sources/tests/test_settings.py
@@ -1,0 +1,19 @@
+"""Tests for the env-overridable USER_AGENT setting."""
+import importlib
+
+import preprint_sources.settings as settings
+
+
+def test_default_user_agent(monkeypatch):
+    monkeypatch.delenv("PREPRINT_SOURCES_USER_AGENT", raising=False)
+    importlib.reload(settings)
+    assert settings.USER_AGENT == "PreprintBot/1.0"
+
+
+def test_env_override(monkeypatch):
+    monkeypatch.setenv("PREPRINT_SOURCES_USER_AGENT", "Custom/9.9")
+    importlib.reload(settings)
+    assert settings.USER_AGENT == "Custom/9.9"
+    # Restore the module to its default state for other tests.
+    monkeypatch.delenv("PREPRINT_SOURCES_USER_AGENT", raising=False)
+    importlib.reload(settings)

--- a/packages/preprint_sources/tests/test_taxonomy.py
+++ b/packages/preprint_sources/tests/test_taxonomy.py
@@ -1,0 +1,48 @@
+"""Tests for the arXiv taxonomy data (well-formedness, not exact contents)."""
+from preprint_sources.taxonomies.arxiv import (
+    ARXIV_CATEGORY_TREE,
+    ARXIV_CODE_TO_LABEL,
+    ARXIV_LEAF_CODES,
+    label_for,
+)
+
+
+def _iter_nodes(nodes):
+    for n in nodes:
+        yield n
+        if n.get("children"):
+            yield from _iter_nodes(n["children"])
+
+
+def _leaf_values(nodes):
+    for n in nodes:
+        if n.get("children"):
+            yield from _leaf_values(n["children"])
+        else:
+            yield n["value"]
+
+
+def test_every_node_has_label_and_value():
+    for node in _iter_nodes(ARXIV_CATEGORY_TREE):
+        assert "label" in node and node["label"]
+        assert "value" in node and node["value"]
+
+
+def test_no_duplicate_leaf_values():
+    leaves = list(_leaf_values(ARXIV_CATEGORY_TREE))
+    assert len(leaves) == len(set(leaves))
+
+
+def test_leaf_codes_nonempty_and_labeled():
+    assert ARXIV_LEAF_CODES
+    for code in ARXIV_LEAF_CODES:
+        assert code in ARXIV_CODE_TO_LABEL
+        assert label_for(code) == ARXIV_CODE_TO_LABEL[code]
+
+
+def test_known_codes_present():
+    assert {"cs.AI", "cs.LG"} <= ARXIV_LEAF_CODES
+
+
+def test_label_for_unknown_returns_code():
+    assert label_for("zzz.NOPE") == "zzz.NOPE"


### PR DESCRIPTION
This pulls out all of the existing preprint server abstraction/details to a dedicated preprint source abstraction helper package. I've also added dedicated tests for the helper package.

Covers 2-4 of #123.

Claude wrote/extracted most of the code. I reviewed.