### PR TITLE
Fix similarity fallback bug

### DIFF
--- a/src/preprint_bot/db_similarity_matcher.py
+++ b/src/preprint_bot/db_similarity_matcher.py
@@ -26,9 +26,12 @@ async def run_similarity_matching(
 ):
     """
     Run similarity matching between user papers and arXiv papers.
-    When paper_ids is provided, only those papers are compared
-    (bypassing any date-based filtering).  Papers are still filtered
-    by the profile's categories when a profile is given.
+    paper_ids restricts which arXiv papers are compared: a set limits the
+    comparison to those papers (an empty set means there is nothing to
+    compare and no recommendations are produced) and None compares against
+    the whole reference corpus.  Restricted papers are filtered further by
+    the profile's categories when a profile is given.  target_date is
+    recorded on the run but does not filter papers.
     """
     
     if isinstance(threshold, str):

--- a/src/preprint_bot/db_similarity_matcher.py
+++ b/src/preprint_bot/db_similarity_matcher.py
@@ -56,10 +56,11 @@ async def run_similarity_matching(
         except Exception as e:
             print(f"  Warning: Could not fetch profile categories: {e}")
     
-    # Determine which arXiv papers to compare against
-    candidate_ids = set(paper_ids) if paper_ids else set()
+    # Determine which arXiv papers to compare against.
+    # None means no restriction; an empty set means restricted to nothing.
+    candidate_ids = set(paper_ids) if paper_ids is not None else None
 
-    if not candidate_ids:
+    if candidate_ids is None:
         print("  Warning: no paper_ids provided, comparing against all arXiv papers in corpus")
 
     # Filter candidates by profile categories
@@ -84,7 +85,7 @@ async def run_similarity_matching(
 
         candidate_ids = filtered
 
-    total_papers_fetched = len(candidate_ids)
+    total_papers_fetched = len(candidate_ids) if candidate_ids is not None else 0
     print(f"  Candidate papers: {total_papers_fetched}")
     
     # Create recommendation run with total_papers_fetched
@@ -100,7 +101,12 @@ async def run_similarity_matching(
         )
     run_id = run["id"]
     print(f"\nCreated recommendation run ID: {run_id}")
-    
+
+    # An explicit but empty candidate set means there is nothing to recommend
+    if candidate_ids is not None and not candidate_ids:
+        print("  No candidate papers after filtering; nothing to recommend.")
+        return run_id
+
     # Fetch embeddings based on mode
     # Fetch embeddings for user's papers
     emb_type = None if use_sections else "abstract"
@@ -108,7 +114,7 @@ async def run_similarity_matching(
     user_embeddings = await api_client.get_embeddings_by_corpus(user_corpus_id, type=emb_type)
     
     # Fetch embeddings for new arXiv papers
-    if candidate_ids:
+    if candidate_ids is not None:
         arxiv_embeddings = await api_client.get_embeddings_by_corpus(
             arxiv_corpus_id, type=emb_type, paper_ids=list(candidate_ids)
         )

--- a/tests/test_similarity_matcher.py
+++ b/tests/test_similarity_matcher.py
@@ -1,6 +1,7 @@
 """Unit tests for similarity computation"""
 import pytest
 import numpy as np
+from unittest.mock import AsyncMock, MagicMock
 
 from pathlib import Path
 import tempfile
@@ -145,6 +146,112 @@ class TestPaperSimilarity:
         # Should return a single float value
         assert isinstance(similarity, float)
         assert -1.0 <= similarity <= 1.0
+
+
+class TestCandidateSelection:
+    """An empty candidate set must mean "recommend nothing", not "compare
+    against every paper in the reference corpus"."""
+
+    def _mock_api_client(self, profile_categories=None, papers=None, run_id=1364):
+        client = AsyncMock()
+        client.base_url = "http://testserver"
+        client.client.get = AsyncMock(
+            return_value=MagicMock(
+                json=MagicMock(return_value={"categories": profile_categories or []})
+            )
+        )
+        client.get_papers_by_corpus = AsyncMock(return_value=papers or [])
+        client.create_recommendation_run = AsyncMock(return_value={"id": run_id})
+        client.get_embeddings_by_corpus = AsyncMock(return_value=[])
+        client.create_recommendation = AsyncMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_empty_paper_ids_stores_no_recommendations(self):
+        """No papers fetched should short-circuit before any embedding fetch."""
+        from preprint_bot.db_similarity_matcher import run_similarity_matching
+
+        client = self._mock_api_client()
+
+        run_id = await run_similarity_matching(
+            client,
+            user_id=1,
+            user_corpus_id=1,
+            arxiv_corpus_id=2,
+            profile_id=None,
+            paper_ids=set(),
+        )
+
+        assert run_id == 1364
+        client.get_embeddings_by_corpus.assert_not_called()
+        client.create_recommendation.assert_not_called()
+        kwargs = client.create_recommendation_run.call_args.kwargs
+        assert kwargs["total_papers_fetched"] == 0
+
+    @pytest.mark.asyncio
+    async def test_category_filter_emptying_candidates_stores_no_recommendations(self):
+        """Candidates filtered down to nothing must not fall back to the corpus."""
+        from preprint_bot.db_similarity_matcher import run_similarity_matching
+
+        client = self._mock_api_client(
+            profile_categories=["cs.GL"],
+            papers=[{"id": 10, "metadata": {"categories": ["cs.LG"]}}],
+        )
+
+        run_id = await run_similarity_matching(
+            client,
+            user_id=1,
+            user_corpus_id=1,
+            arxiv_corpus_id=2,
+            profile_id=7,
+            paper_ids={10},
+        )
+
+        assert run_id == 1364
+        client.get_embeddings_by_corpus.assert_not_called()
+        client.create_recommendation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_surviving_candidates_restrict_the_embedding_fetch(self):
+        """Candidates that pass the category filter are the only ones fetched."""
+        from preprint_bot.db_similarity_matcher import run_similarity_matching
+
+        client = self._mock_api_client(
+            profile_categories=["cs.GL"],
+            papers=[{"id": 10, "metadata": {"categories": ["cs.GL"]}}],
+        )
+
+        await run_similarity_matching(
+            client,
+            user_id=1,
+            user_corpus_id=1,
+            arxiv_corpus_id=2,
+            profile_id=7,
+            paper_ids={10},
+        )
+
+        # First call is the user corpus, second is the restricted arXiv fetch.
+        arxiv_call = client.get_embeddings_by_corpus.call_args_list[1]
+        assert arxiv_call.kwargs["paper_ids"] == [10]
+
+    @pytest.mark.asyncio
+    async def test_no_paper_ids_still_compares_against_whole_corpus(self):
+        """paper_ids=None keeps the unrestricted behaviour for ad-hoc callers."""
+        from preprint_bot.db_similarity_matcher import run_similarity_matching
+
+        client = self._mock_api_client()
+
+        await run_similarity_matching(
+            client,
+            user_id=1,
+            user_corpus_id=1,
+            arxiv_corpus_id=2,
+            profile_id=None,
+            paper_ids=None,
+        )
+
+        arxiv_call = client.get_embeddings_by_corpus.call_args_list[1]
+        assert "paper_ids" not in arxiv_call.kwargs
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If no papers are available for a given profile's preferred categories, we then short-circuit and skip any similarity calculations.

Fixes #129